### PR TITLE
Protocol of uploaded file based on X-Forwarded-Proto

### DIFF
--- a/copyparty/httpcli.py
+++ b/copyparty/httpcli.py
@@ -94,6 +94,7 @@ class HttpCli(object):
     def run(self):
         """returns true if connection can be reused"""
         self.keepalive = False
+        self.is_https = False
         self.headers = {}
         self.hint = None
         try:
@@ -131,6 +132,7 @@ class HttpCli(object):
 
         v = self.headers.get("connection", "").lower()
         self.keepalive = not v.startswith("close") and self.http_ver != "HTTP/1.0"
+        self.is_https = (self.headers.get("x-forwarded-proto", "").lower() == "https" or self.tls)
 
         n = self.args.rproxy
         if n:
@@ -1127,10 +1129,9 @@ class HttpCli(object):
             )
             # truncated SHA-512 prevents length extension attacks;
             # using SHA-512/224, optionally SHA-512/256 = :64
-            is_https = (self.headers.get("x-forwarded-proto") == "https" or self.tls)
             jpart = {
                 "url": "{}://{}/{}".format(
-                    "https" if is_https else "http",
+                    "https" if self.is_https else "http",
                     self.headers.get("host", "copyparty"),
                     vpath + vsuf,
                 ),

--- a/copyparty/httpcli.py
+++ b/copyparty/httpcli.py
@@ -1127,9 +1127,10 @@ class HttpCli(object):
             )
             # truncated SHA-512 prevents length extension attacks;
             # using SHA-512/224, optionally SHA-512/256 = :64
+            is_https = (self.headers.get("x-forwarded-proto") == "https" or self.tls)
             jpart = {
                 "url": "{}://{}/{}".format(
-                    "https" if self.tls else "http",
+                    "https" if is_https else "http",
                     self.headers.get("host", "copyparty"),
                     vpath + vsuf,
                 ),


### PR DESCRIPTION
When a file's uploaded, the file URL returned comes with either "http://" or "https://" depending if TLS is being used.
If you're using a reverse proxy, it'll return http on the URL even if you're actually connecting to the proxy through https (and then http to copyparty)

X-Forwarded-Proto or X-Forwarded-Ssl seem like the most standard headers for informing this.