### PR TITLE
Nix/NixOS support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ up.*.txt
 .hist/
 scripts/docker/*.out
 scripts/docker/*.err
+
+# nix build output link
+result

--- a/README.md
+++ b/README.md
@@ -1138,32 +1138,62 @@ for this setup, you will need a [flake-enabled](https://nixos.wiki/wiki/Flakes) 
 }
 ```
 
-copyparty on NixOS is configured via `services.copyparty.config`, for example:
+copyparty on NixOS is configured via `services.copyparty` options, for example:
 ```nix
 services.copyparty = {
   enable = true;
-  config = ''
-    [global]
-      i: 0.0.0.0
-      no-reload
+  # directly maps to values in the [global] section of the copyparty config.
+  # see `copyparty --help` for available options
+  settings = {
+    i = "0.0.0.0";
+    # use lists to set multiple values
+    p = [ 3210 3211 ];
+    # use booleans to set binary flags
+    no-reload = true;
+    # using 'false' will do nothing and omit the value when generating a config
+    ignored-flag = false;
+  };
 
-    # create users
-    [accounts]
-      # username: password
-      ed: 123
+  # create users
+  accounts = {
+    # specify the account name as the key
+    ed = {
+      # provide the path to a file containing the password, keeping it out of /nix/store
+      # must be readable by the copyparty service user
+      passwordFile = "/run/keys/copyparty/ed_password";
+    };
+    # or do both in one go
+    k.passwordFile = "/run/keys/copyparty/k_password";
+  };
 
-    # create a volume
-    [/]               # create a volume at "/" (the webroot), which will
-      /srv/copyparty  # share the contents of "/srv/copyparty"
-      accs:
-        r: *          # everyone gets read-access, but
-        rw: ed        # the user "ed" gets read-write
-  '';
-  # the service runs in an isolated environment by default
-  # any directory you reference in the volume configuration
-  # needs to be added here, in order to make it discoverable
-  # with the exception of /var/lib/copyparty, which is always available
-  readWritePaths = [ "/srv/copyparty" ];
+  # create a volume
+  volumes = {
+    # create a volume at "/" (the webroot), which will
+    "/" = {
+      # share the contents of "/srv/copyparty"
+      path = "/srv/copyparty";
+      # see `copyparty --help-accounts` for available options
+      access = {
+        # everyone gets read-access, but
+        r = "*";
+        # users "ed" and "k" get read-write
+        rw = [ "ed" "k" ];
+      };
+      # see `copyparty --help-flags` for available options
+      flags = {
+        # "fk" enables filekeys (necessary for upget permission) (4 chars long)
+        fk = 4;
+        # scan for new files every 60sec
+        scan = 60;
+        # volflag "e2d" enables the uploads database
+        e2d = true;
+        # "d2t" disables multimedia parsers (in case the uploads are malicious)
+        d2t = true;
+        # skips hashing file contents if path matches *.iso
+        nohash = "\.iso$";
+      };
+    };
+  };
   # you may increase the open file limit for the process
   openFilesLimit = 8192;
 };

--- a/README.md
+++ b/README.md
@@ -99,6 +99,8 @@ just run **[copyparty-sfx.py](https://github.com/9001/copyparty/releases/latest/
 
 * or install through pypi (python3 only): `python3 -m pip install --user -U copyparty`
 * or if you cannot install python, you can use [copyparty.exe](#copypartyexe) instead
+* or install through nix: `nix profile install github:9001/copyparty`
+  * requires a [flake-enabled](https://nixos.wiki/wiki/Flakes) installation of nix
 * or if you are on android, [install copyparty in termux](#install-on-android)
 * or if you prefer to [use docker](./scripts/docker/) 🐋 you can do that too
   * docker has all deps built-in, so skip this step:
@@ -134,6 +136,7 @@ you may also want these, especially on servers:
 * [contrib/systemd/prisonparty.service](contrib/systemd/prisonparty.service) to run it in a chroot (for extra security)
 * [contrib/rc/copyparty](contrib/rc/copyparty) to run copyparty on FreeBSD
 * [contrib/nginx/copyparty.conf](contrib/nginx/copyparty.conf) to [reverse-proxy](#reverse-proxy) behind nginx (for better https)
+* [nixos module](#nixos-module) to run copyparty on NixOS hosts
 
 and remember to open the ports you want; here's a complete example including every feature copyparty has to offer:
 ```
@@ -1107,6 +1110,64 @@ example webserver configs:
 * [nginx config](contrib/nginx/copyparty.conf) -- entire domain/subdomain
 * [apache2 config](contrib/apache/copyparty.conf) -- location-based
 
+## nixos module
+for this setup, you will need a [flake-enabled](https://nixos.wiki/wiki/Flakes) installation of NixOS.
+
+```nix
+{
+  # add copyparty flake to your inputs
+  inputs.copyparty.url = "github:9001/copyparty";
+
+  # ensure that copyparty is an allowed argument to the outputs function
+  outputs = { self, nixpkgs, copyparty }: {
+    nixosConfigurations.yourHostName = nixpkgs.lib.nixosSystem {
+      modules = [
+        # load the copyparty NixOS module
+        copyparty.nixosModules.default
+        ({ pkgs, ... }: {
+          # add the copyparty overlay to expose the package to the module
+          nixpkgs.overlays = [ copyparty.overlays.default ];
+          # (optional) install the package globally
+          environment.systemPackages = [ pkgs.copyparty ];
+          # configure the copyparty module
+          services.copyparty.enable = true;
+        })
+      ];
+    };
+  };
+}
+```
+
+copyparty on NixOS is configured via `services.copyparty.config`, for example:
+```nix
+services.copyparty = {
+  enable = true;
+  config = ''
+    [global]
+      i: 0.0.0.0
+      no-reload
+
+    # create users
+    [accounts]
+      # username: password
+      ed: 123
+
+    # create a volume
+    [/]               # create a volume at "/" (the webroot), which will
+      /srv/copyparty  # share the contents of "/srv/copyparty"
+      accs:
+        r: *          # everyone gets read-access, but
+        rw: ed        # the user "ed" gets read-write
+  '';
+  # the service runs in an isolated environment by default
+  # any directory you reference in the volume configuration
+  # needs to be added here, in order to make it discoverable
+  # with the exception of /var/lib/copyparty, which is always available
+  readWritePaths = [ "/srv/copyparty" ];
+  # you may increase the open file limit for the process
+  openFilesLimit = 8192;
+};
+```
 
 # browser support
 

--- a/contrib/nixos/modules/copyparty.nix
+++ b/contrib/nixos/modules/copyparty.nix
@@ -3,11 +3,57 @@
 with lib;
 
 let
+  mkKeyValue = key: value:
+    if value == true then
+    # sets with a true boolean value are coerced to just the key name
+      key
+    else if value == false then
+    # or omitted completely when false
+      ""
+    else
+      (generators.mkKeyValueDefault { inherit mkValueString; } ": " key value);
+
+  mkAttrsString = value: (generators.toKeyValue { inherit mkKeyValue; } value);
+
+  mkValueString = value:
+    if isList value then
+      (concatStringsSep ", " (map mkValueString value))
+    else if isAttrs value then
+      "\n" + (mkAttrsString value)
+    else
+      (generators.mkValueStringDefault { } value);
+
+  mkSectionName = value: "[" + (escape [ "[" "]" ] value) + "]";
+
+  mkSection = name: attrs: ''
+    ${mkSectionName name}
+    ${mkAttrsString attrs}
+  '';
+
+  mkVolume = name: attrs: ''
+    ${mkSectionName name}
+    ${attrs.path}
+    ${mkAttrsString {
+      accs = attrs.access;
+      flags = attrs.flags;
+    }}
+  '';
+
+  passwordPlaceholder = name: "{{password-${name}}}";
+
+  accountsWithPlaceholders = mapAttrs (name: attrs: passwordPlaceholder name);
+
+  configStr = ''
+    ${mkSection "global" cfg.settings}
+    ${mkSection "accounts" (accountsWithPlaceholders cfg.accounts)}
+    ${concatStringsSep "\n" (mapAttrsToList mkVolume cfg.volumes)}
+  '';
+
   name = "copyparty";
   cfg = config.services.copyparty;
-  configFile = pkgs.writeText "copyparty.conf" cfg.config;
-  bin = "${cfg.package}/bin/${name}";
-  home = "/var/lib/copyparty";
+  configFile = pkgs.writeText "${name}.conf" configStr;
+  runtimeConfigPath = "/run/${name}/${name}.conf";
+  home = "/var/lib/${name}";
   defaultShareDir = "${home}/data";
 in {
   options.services.copyparty = {
@@ -22,49 +68,136 @@ in {
       '';
     };
 
-    readWritePaths = mkOption {
-      default = [ ];
-      type = types.listOf types.str;
-      description = "Paths permitted for read/write.";
-    };
-
     openFilesLimit = mkOption {
       default = 4096;
       type = types.either types.int types.str;
       description = "Number of files to allow copyparty to open.";
     };
 
-    config = mkOption {
-      type = types.lines;
-      description =
-        "Configuration file. See https://github.com/9001/copyparty#server-config for reference";
-      default = ''
-        [global]
-          i: 127.0.0.1
-          no-reload
-
-        # create a volume:
-        [/]                   # create a volume at "/" (the webroot), which will
-          ${defaultShareDir}  # share the contents of "${defaultShareDir}"
-          accs:
-            r: *              # everyone gets read-access, but
+    settings = mkOption {
+      type = types.attrs;
+      description = ''
+        Global settings to apply.
+        Directly maps to values in the [global] section of the copyparty config.
+        See `${getExe cfg.package} --help` for more details.
       '';
-      example = ''
-        [global]
-          i: 0.0.0.0
-          no-reload
+      default = {
+        i = "127.0.0.1";
+        no-reload = true;
+      };
+      example = literalExpression ''
+        {
+          i = "0.0.0.0";
+          no-reload = true;
+        }
+      '';
+    };
 
-        # create users:
-        [accounts]
-          # username: password
-          ed: 123
+    accounts = mkOption {
+      type = types.attrsOf (types.submodule ({ ... }: {
+        options = {
+          passwordFile = mkOption {
+            type = types.str;
+            description = ''
+              Runtime file path to a file containing the user password.
+              Must be readable by the copyparty user.
+            '';
+            example = "/run/keys/copyparty/ed";
+          };
+        };
+      }));
+      description = ''
+        A set of copyparty accounts to create.
+      '';
+      default = { };
+      example = literalExpression ''
+        {
+          ed.passwordFile = "/run/keys/copyparty/ed";
+        };
+      '';
+    };
 
-        # create a volume:
-        [/]                   # create a volume at "/" (the webroot), which will
-          ${defaultShareDir}  # share the contents of "${defaultShareDir}"
-          accs:
-            r: *              # everyone gets read-access, but
-            rw: ed            # the user "ed" gets read-write
+    volumes = mkOption {
+      type = types.attrsOf (types.submodule ({ ... }: {
+        options = {
+          path = mkOption {
+            type = types.str;
+            description = ''
+              Path of a directory to share.
+            '';
+          };
+          access = mkOption {
+            type = types.attrs;
+            description = ''
+              Attribute list of permissions and the users to apply them to.
+
+              The key must be a string containing any combination of allowed permission:
+                "r" (read):   list folder contents, download files
+                "w" (write):  upload files; need "r" to see the uploads
+                "m" (move):   move files and folders; need "w" at destination
+                "d" (delete): permanently delete files and folders
+                "g" (get):    download files, but cannot see folder contents
+                "G" (upget):  "get", but can see filekeys of their own uploads
+
+              For example: "rwmd"
+
+              The value must be one of:
+                an account name, defined in `accounts`
+                a list of account names
+                "*", which means "any account"
+            '';
+            example = literalExpression ''
+              {
+                # wG = write-upget = see your own uploads only
+                wG = "*";
+                # read-write-modify-delete for users "ed" and "k"
+                rwmd = ["ed" "k"];
+              };
+            '';
+          };
+          flags = mkOption {
+            type = types.attrs;
+            description = ''
+              Attribute list of volume flags to apply.
+              See `${getExe cfg.package} --help-flags` for more details.
+            '';
+            example = literalExpression ''
+              {
+                # "fk" enables filekeys (necessary for upget permission) (4 chars long)
+                fk = 4;
+                # scan for new files every 60sec
+                scan = 60;
+                # volflag "e2d" enables the uploads database
+                e2d = true;
+                # "d2t" disables multimedia parsers (in case the uploads are malicious)
+                d2t = true;
+                # skips hashing file contents if path matches *.iso
+                nohash = "\.iso$";
+              };
+            '';
+            default = { };
+          };
+        };
+      }));
+      description = "A set of copyparty volumes to create";
+      default = {
+        "/" = {
+          path = defaultShareDir;
+          access = { r = "*"; };
+        };
+      };
+      example = literalExpression ''
+        {
+          "/" = {
+            path = ${defaultShareDir};
+            access = {
+              # wG = write-upget = see your own uploads only
+              wG = "*";
+              # read-write-modify-delete for users "ed" and "k"
+              rwmd = ["ed" "k"];
+            };
+          };
+        };
       '';
     };
   };
@@ -79,20 +212,29 @@ in {
         XDG_CONFIG_HOME = "${home}/.config";
       };
 
-      preStart = ''
-        mkdir -p "$XDG_CONFIG_HOME"
-        mkdir -p "${defaultShareDir}"
+      preStart = let
+        replaceSecretCommand = name: attrs:
+          "${getExe pkgs.replace-secret} '${
+            passwordPlaceholder name
+          }' '${attrs.passwordFile}' ${runtimeConfigPath}";
+      in ''
+        set -euo pipefail
+        install -m 600 ${configFile} ${runtimeConfigPath}
+        ${concatStringsSep "\n"
+        (mapAttrsToList replaceSecretCommand cfg.accounts)}
       '';
 
       serviceConfig = {
         Type = "simple";
-        ExecStart = "${bin} -c ${configFile}";
+        ExecStart = "${getExe cfg.package} -c ${runtimeConfigPath}";
 
         # Hardening options
         User = "copyparty";
         Group = "copyparty";
-        StateDirectory = "copyparty";
-        StateDirectoryMode = "0755";
+        RuntimeDirectory = name;
+        RuntimeDirectoryMode = "0700";
+        StateDirectory = [ name "${name}/data" "${name}/.config" ];
+        StateDirectoryMode = "0700";
         WorkingDirectory = home;
         TemporaryFileSystem = "/:ro";
         BindReadOnlyPaths = [
@@ -101,8 +243,8 @@ in {
           "-/etc/nsswitch.conf"
           "-/etc/hosts"
           "-/etc/localtime"
-        ];
-        BindPaths = [ home ] ++ cfg.readWritePaths;
+        ] ++ (mapAttrsToList (k: v: "-${v.passwordFile}") cfg.accounts);
+        BindPaths = [ home ] ++ (mapAttrsToList (k: v: v.path) cfg.volumes);
         # Would re-mount paths ignored by temporary root
         #ProtectSystem = "strict";
         ProtectHome = true;
@@ -125,7 +267,6 @@ in {
         NoNewPrivileges = true;
         LockPersonality = true;
         RestrictRealtime = true;
-        RestrictAddressFamilies = "AF_INET AF_INET6";
       };
     };
 

--- a/contrib/nixos/modules/copyparty.nix
+++ b/contrib/nixos/modules/copyparty.nix
@@ -1,0 +1,140 @@
+{ config, pkgs, lib, ... }:
+
+with lib;
+
+let
+  name = "copyparty";
+  cfg = config.services.copyparty;
+  configFile = pkgs.writeText "copyparty.conf" cfg.config;
+  bin = "${cfg.package}/bin/${name}";
+  home = "/var/lib/copyparty";
+  defaultShareDir = "${home}/data";
+in {
+  options.services.copyparty = {
+    enable = mkEnableOption "web-based file manager";
+
+    package = mkOption {
+      type = types.package;
+      default = pkgs.copyparty;
+      defaultText = "pkgs.copyparty";
+      description = ''
+        Package of the application to run, exposed for overriding purposes.
+      '';
+    };
+
+    readWritePaths = mkOption {
+      default = [ ];
+      type = types.listOf types.str;
+      description = "Paths permitted for read/write.";
+    };
+
+    openFilesLimit = mkOption {
+      default = 4096;
+      type = types.either types.int types.str;
+      description = "Number of files to allow copyparty to open.";
+    };
+
+    config = mkOption {
+      type = types.lines;
+      description =
+        "Configuration file. See https://github.com/9001/copyparty#server-config for reference";
+      default = ''
+        [global]
+          i: 127.0.0.1
+          no-reload
+
+        # create a volume:
+        [/]                   # create a volume at "/" (the webroot), which will
+          ${defaultShareDir}  # share the contents of "${defaultShareDir}"
+          accs:
+            r: *              # everyone gets read-access, but
+      '';
+      example = ''
+        [global]
+          i: 0.0.0.0
+          no-reload
+
+        # create users:
+        [accounts]
+          # username: password
+          ed: 123
+
+        # create a volume:
+        [/]                   # create a volume at "/" (the webroot), which will
+          ${defaultShareDir}  # share the contents of "${defaultShareDir}"
+          accs:
+            r: *              # everyone gets read-access, but
+            rw: ed            # the user "ed" gets read-write
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    systemd.services.copyparty = {
+      description = "http file sharing hub";
+      wantedBy = [ "multi-user.target" ];
+
+      environment = {
+        PYTHONUNBUFFERED = "true";
+        XDG_CONFIG_HOME = "${home}/.config";
+      };
+
+      preStart = ''
+        mkdir -p "$XDG_CONFIG_HOME"
+        mkdir -p "${defaultShareDir}"
+      '';
+
+      serviceConfig = {
+        Type = "simple";
+        ExecStart = "${bin} -c ${configFile}";
+
+        # Hardening options
+        User = "copyparty";
+        Group = "copyparty";
+        StateDirectory = "copyparty";
+        StateDirectoryMode = "0755";
+        WorkingDirectory = home;
+        TemporaryFileSystem = "/:ro";
+        BindReadOnlyPaths = [
+          "/nix/store"
+          "-/etc/resolv.conf"
+          "-/etc/nsswitch.conf"
+          "-/etc/hosts"
+          "-/etc/localtime"
+        ];
+        BindPaths = [ home ] ++ cfg.readWritePaths;
+        # Would re-mount paths ignored by temporary root
+        #ProtectSystem = "strict";
+        ProtectHome = true;
+        PrivateTmp = true;
+        PrivateDevices = true;
+        ProtectKernelTunables = true;
+        ProtectControlGroups = true;
+        RestrictSUIDSGID = true;
+        PrivateMounts = true;
+        ProtectKernelModules = true;
+        ProtectKernelLogs = true;
+        ProtectHostname = true;
+        ProtectClock = true;
+        ProtectProc = "invisible";
+        ProcSubset = "pid";
+        RestrictNamespaces = true;
+        RemoveIPC = true;
+        UMask = "0077";
+        LimitNOFILE = cfg.openFilesLimit;
+        NoNewPrivileges = true;
+        LockPersonality = true;
+        RestrictRealtime = true;
+        RestrictAddressFamilies = "AF_INET AF_INET6";
+      };
+    };
+
+    users.groups.copyparty = { };
+    users.users.copyparty = {
+      description = "Service user for copyparty";
+      group = "copyparty";
+      home = home;
+      isSystemUser = true;
+    };
+  };
+}

--- a/contrib/package/nix/copyparty/default.nix
+++ b/contrib/package/nix/copyparty/default.nix
@@ -9,7 +9,6 @@ let
       jinja2
       # thumbnails
       pyvips
-      ffmpeg
       # alternative thumbnails, but not needed in the presence of pyvips and ffmpeg
       # pillow pyheif-pillow-opener pillow-avif-plugin
       # audio metadata

--- a/contrib/package/nix/copyparty/default.nix
+++ b/contrib/package/nix/copyparty/default.nix
@@ -20,7 +20,7 @@ let
       # smb server
       impacket
     ]);
-in stdenv.mkDerivation rec {
+in stdenv.mkDerivation {
   pname = "copyparty";
   version = pinData.version;
   src = fetchurl {

--- a/contrib/package/nix/copyparty/default.nix
+++ b/contrib/package/nix/copyparty/default.nix
@@ -2,6 +2,7 @@
 , pyvips, pyftpdlib, pyopenssl, impacket, ffmpeg }:
 
 let
+  pinData = lib.importJSON ./pin.json;
   pyEnv = python.withPackages (ps:
     with ps; [
       # mandatory
@@ -21,11 +22,10 @@ let
     ]);
 in stdenv.mkDerivation rec {
   pname = "copyparty";
-  version = "1.6.11";
+  version = pinData.version;
   src = fetchurl {
-    url =
-      "https://github.com/9001/copyparty/releases/download/v${version}/copyparty-sfx.py";
-    hash = "sha256-0JbjOrZm70UhOJndOhBzX2K1RBM5y3N0+TsjLQtsjTQ=";
+    url = pinData.url;
+    hash = pinData.hash;
   };
   buildInputs = [ makeWrapper ];
   dontUnpack = true;

--- a/contrib/package/nix/copyparty/default.nix
+++ b/contrib/package/nix/copyparty/default.nix
@@ -1,0 +1,39 @@
+{ lib, stdenv, makeWrapper, fetchurl, utillinux, python, jinja2, mutagen, pillow
+, pyvips, pyftpdlib, pyopenssl, impacket, ffmpeg }:
+
+let
+  pyEnv = python.withPackages (ps:
+    with ps; [
+      # mandatory
+      jinja2
+      # thumbnails
+      pyvips
+      ffmpeg
+      # alternative thumbnails, but not needed in the presence of pyvips and ffmpeg
+      # pillow pyheif-pillow-opener pillow-avif-plugin
+      # audio metadata
+      mutagen
+      # ftp server
+      pyftpdlib
+      pyopenssl
+      # smb server
+      impacket
+    ]);
+in stdenv.mkDerivation rec {
+  pname = "copyparty";
+  version = "1.6.11";
+  src = fetchurl {
+    url =
+      "https://github.com/9001/copyparty/releases/download/v${version}/copyparty-sfx.py";
+    hash = "sha256-0JbjOrZm70UhOJndOhBzX2K1RBM5y3N0+TsjLQtsjTQ=";
+  };
+  buildInputs = [ makeWrapper ];
+  dontUnpack = true;
+  dontBuild = true;
+  installPhase = ''
+    install -Dm755 $src $out/share/copyparty-sfx.py
+    makeWrapper ${pyEnv.interpreter} $out/bin/copyparty \
+      --set PATH '${lib.makeBinPath [ utillinux ffmpeg ]}:$PATH' \
+      --add-flags "$out/share/copyparty-sfx.py"
+  '';
+}

--- a/contrib/package/nix/copyparty/pin.json
+++ b/contrib/package/nix/copyparty/pin.json
@@ -1,0 +1,5 @@
+{
+    "url": "https://github.com/9001/copyparty/releases/download/v1.6.11/copyparty-sfx.py",
+    "version": "1.6.11",
+    "hash": "sha256-0JbjOrZm70UhOJndOhBzX2K1RBM5y3N0+TsjLQtsjTQ="
+}

--- a/contrib/package/nix/copyparty/update.py
+++ b/contrib/package/nix/copyparty/update.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+
+# Update the Nix package pin
+#
+# Usage: ./update.sh [PATH]
+# When the [PATH] is not set, it will fetch the latest release from the repo.
+# With [PATH] set, it will hash the given file and generate the URL,
+# base on the version contained within the file
+
+import base64
+import json
+import hashlib
+import sys
+import re
+from pathlib import Path
+
+OUTPUT_FILE = Path("pin.json")
+TARGET_ASSET = "copyparty-sfx.py"
+HASH_TYPE = "sha256"
+LATEST_RELEASE_URL = "https://api.github.com/repos/9001/copyparty/releases/latest"
+DOWNLOAD_URL = lambda version: f"https://github.com/9001/copyparty/releases/download/v{version}/{TARGET_ASSET}"
+
+
+def get_formatted_hash(binary):
+    hasher = hashlib.new("sha256")
+    hasher.update(binary)
+    asset_hash = hasher.digest()
+    encoded_hash = base64.b64encode(asset_hash).decode("ascii")
+    return f"{HASH_TYPE}-{encoded_hash}"
+
+
+def version_from_sfx(binary):
+    result = re.search(b'^VER = "(.*)"$', binary, re.MULTILINE)
+    if result:
+        return result.groups(1)[0].decode("ascii")
+
+    raise ValueError("version not found in provided file")
+
+
+def remote_release_pin():
+    import requests
+
+    response = requests.get(LATEST_RELEASE_URL).json()
+    version = response["tag_name"].lstrip("v")
+    asset_info = [a for a in response["assets"] if a["name"] == TARGET_ASSET][0]
+    download_url = asset_info["browser_download_url"]
+    asset = requests.get(download_url)
+    formatted_hash = get_formatted_hash(asset.content)
+
+    result = {"url": download_url, "version": version, "hash": formatted_hash}
+    return result
+
+
+def local_release_pin(path):
+    asset = path.read_bytes()
+    version = version_from_sfx(asset)
+    download_url = DOWNLOAD_URL(version)
+    formatted_hash = get_formatted_hash(asset)
+
+    result = {"url": download_url, "version": version, "hash": formatted_hash}
+    return result
+
+
+def main():
+    if len(sys.argv) > 1:
+        asset_path = Path(sys.argv[1])
+        result = local_release_pin(asset_path)
+    else:
+        result = remote_release_pin()
+
+    print(result)
+    json_result = json.dumps(result, indent=4)
+    OUTPUT_FILE.write_text(json_result)
+
+
+if __name__ == "__main__":
+    main()

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,42 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1678901627,
+        "narHash": "sha256-U02riOqrKKzwjsxc/400XnElV+UtPUQWpANPlyazjH0=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "93a2b84fc4b70d9e089d029deacc3583435c2ed6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1680334310,
+        "narHash": "sha256-ISWz16oGxBhF7wqAxefMPwFag6SlsA9up8muV79V9ck=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "884e3b68be02ff9d61a042bc9bd9dd2a358f95da",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "ref": "nixos-22.11",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,27 @@
+{
+  inputs = {
+    nixpkgs.url = "nixpkgs/nixos-22.11";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    {
+      overlays.default = self: super: {
+        copyparty =
+          self.python3.pkgs.callPackage ./contrib/package/nix/copyparty {
+            ffmpeg = self.ffmpeg-full;
+          };
+      };
+    } // flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs {
+          inherit system;
+          overlays = [ self.overlays.default ];
+        };
+      in {
+        packages = {
+          inherit (pkgs) copyparty;
+          default = self.packages.${system}.copyparty;
+        };
+      });
+}

--- a/flake.nix
+++ b/flake.nix
@@ -6,6 +6,7 @@
 
   outputs = { self, nixpkgs, flake-utils }:
     {
+      nixosModules.default = ./contrib/nixos/modules/copyparty.nix;
       overlays.default = self: super: {
         copyparty =
           self.python3.pkgs.callPackage ./contrib/package/nix/copyparty {


### PR DESCRIPTION
This PR adds:
- a Nix package
- a NixOS module
- simple documentation on how to use these
- a script for easily updating the package

The package is built using the sfx release. It adds most of the necessary dependencies.
Other scripts such as up2k are not included, but this could be done in the future.
It's intentionally omitting Pillow, since it looks like all the extensions are handled by either vips or ffmpeg, which are included.
I did not bother with support for vamp/vamp-sdk and related memes. This is something I could do eventually, but I've suffered enough for now.

The NixOS module is running copyparty in a restricted environment by default, kinda like prisonparty, but using systemd features around namespaces instead of a chroot. 
I did manually test the features that looked like they could break and everything seems to work.
Only additional requirement is that the user has to specify read/write paths in the configuration. This could be automated by specifying the copyparty configuration as a nix module and serializing the real config from it. This would give us the ability to read parts of the config and deriving which paths should be readable/writable.
Given that the config format used is not compliant with any existing format that I know of, I did not bother doing that.
Another quirk, which is more on the copyparty to fix, is that the certificates live in `$XDG_CONFIG_HOME`, with no ability to configure it. That means that unless the user manually modifies the certificates in `/var/lib/copyparty`, it will use a self-signed certificate. This could be worked around in the NixOS module, but it would be a lot less hacky, if the cert path was configurable.

I've also included a script for updating the Nix package in `contrib/packages/nix/copyparty/update.py`.
It will download the latest sfx.py from github and put its version and hash in `pin.json`, which is then used by the Nix derivation.
I then immediately realized that this mode of operation sucks for maintainers, because you won't have a release when it would make sense to run the script, which is just before adding a tag.
That's why you can also give `update.py` a path to an sfx file and it will update `pin.json` with a version contained within. That might break because I have some shitty regex doing it, but it should be good enough.


This PR complies with the DCO; https://developercertificate.org/  
