### PR TITLE
RFC: Python 3.7 package resources support

### DIFF
--- a/copyparty/__init__.py
+++ b/copyparty/__init__.py
@@ -54,6 +54,7 @@ except:
 
 class EnvParams(object):
     def __init__(self) -> None:
+        self.pkg = ""
         self.t0 = time.time()
         self.mod = ""
         self.cfg = ""

--- a/copyparty/__init__.py
+++ b/copyparty/__init__.py
@@ -54,7 +54,7 @@ except:
 
 class EnvParams(object):
     def __init__(self) -> None:
-        self.pkg = ""
+        self.pkg = None
         self.t0 = time.time()
         self.mod = ""
         self.cfg = ""

--- a/copyparty/__main__.py
+++ b/copyparty/__main__.py
@@ -217,7 +217,7 @@ def init_E(EE: EnvParams) -> None:
 
         raise Exception("could not find a writable path for config")
 
-    E.pkg = __package__
+    E.pkg = sys.modules[__package__]
     E.mod = os.path.dirname(os.path.realpath(__file__))
     if E.mod.endswith("__init__"):
         E.mod = os.path.dirname(E.mod)

--- a/copyparty/__main__.py
+++ b/copyparty/__main__.py
@@ -217,6 +217,7 @@ def init_E(EE: EnvParams) -> None:
 
         raise Exception("could not find a writable path for config")
 
+    E.pkg = __package__
     E.mod = os.path.dirname(os.path.realpath(__file__))
     if E.mod.endswith("__init__"):
         E.mod = os.path.dirname(E.mod)

--- a/copyparty/__main__.py
+++ b/copyparty/__main__.py
@@ -57,6 +57,7 @@ from .util import (
     ansi_re,
     b64enc,
     dedent,
+    has_resource,
     min_ex,
     pybin,
     termsize,
@@ -325,8 +326,7 @@ def ensure_locale() -> None:
 
 
 def ensure_webdeps() -> None:
-    ap = os.path.join(E.mod, "web/deps/mini-fa.woff")
-    if os.path.exists(ap):
+    if has_resource(E, "web/deps/mini-fa.woff"):
         return
 
     warn(

--- a/copyparty/httpconn.py
+++ b/copyparty/httpconn.py
@@ -103,9 +103,6 @@ class HttpConn(object):
         self.log_src = ("%s \033[%dm%d" % (ip, color, self.addr[1])).ljust(26)
         return self.log_src
 
-    def respath(self, res_name: str) -> str:
-        return os.path.join(self.E.mod, "web", res_name)
-
     def log(self, msg: str, c: Union[int, str] = 0) -> None:
         self.log_func(self.log_src, msg, c)
 

--- a/copyparty/util.py
+++ b/copyparty/util.py
@@ -3563,7 +3563,10 @@ def hidedir(dp) -> None:
 try:
     import importlib.resources as impresources
 except ImportError:
-    impresources = None
+    try:
+        import importlib_resources as impresources
+    except ImportError:
+        impresources = None
 
 
 def stat_resource(E: EnvParams, name: str):

--- a/copyparty/util.py
+++ b/copyparty/util.py
@@ -3417,9 +3417,14 @@ def loadpy(ap: str, hot: bool) -> Any:
 
 def gzip_orig_sz(fn: str) -> int:
     with open(fsenc(fn), "rb") as f:
-        f.seek(-4, 2)
-        rv = f.read(4)
-        return sunpack(b"I", rv)[0]  # type: ignore
+        return gzip_file_orig_sz(f)
+
+def gzip_file_orig_sz(f) -> int:
+    start = f.tell()
+    f.seek(-4, 2)
+    rv = f.read(4)
+    f.seek(start, 0)
+    return sunpack(b"I", rv)[0]  # type: ignore
 
 
 def align_tab(lines: list[str]) -> list[str]:

--- a/copyparty/util.py
+++ b/copyparty/util.py
@@ -3576,7 +3576,7 @@ def stat_resource(E: EnvParams, name: str):
 def has_resource(E: EnvParams, name: str):
     if impresources:
         try:
-            resources = impresources.files("copyparty")
+            resources = impresources.files(E.pkg)
         except ImportError:
             pass
         else:
@@ -3590,7 +3590,7 @@ def has_resource(E: EnvParams, name: str):
 def load_resource(E: EnvParams, name: str, mode="rb"):
     if impresources:
         try:
-            resources = impresources.files("copyparty")
+            resources = impresources.files(E.pkg)
         except ImportError:
             pass
         else:
@@ -3618,7 +3618,7 @@ def walk_resources(E: EnvParams, name: str):
 
     if impresources:
         try:
-            resources = impresources.files("copyparty").joinpath(name)
+            resources = impresources.files(E.pkg).joinpath(name)
         except ImportError:
             resources = None
     else:


### PR DESCRIPTION
This series of patches adds support for loading web resources through Python's `importlib.resources` abstraction, allowing them to be packed into whatever module loading mechanism is used (e.g. `zipimport`). This would allow distributing copyparty as a single `.py` without needing any kind of file system access in `/tmp` or elsewhere.

Three pending improvements that make it RFC for now:
- ~~Make package name used for access configurable through `E` instead of hardcoded in `util.py`~~
- Verify `walk_resources()` correctness
- ~~Add support for the older [`pkg_resources`](https://setuptools.pypa.io/en/latest/pkg_resources.html) API~~