### PR TITLE
Allow multiple CIDR ranges in `build_netmap` when using LAN shorthands

### DIFF
--- a/copyparty/util.py
+++ b/copyparty/util.py
@@ -2709,12 +2709,21 @@ def build_netmap(csv: str, defer_mutex: bool = False):
     if csv in ("any", "all", "no", ",", ""):
         return None
 
-    if csv in ("lan", "local", "private", "prvt"):
-        csv = "10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16, fd00::/8"  # lan
-        csv += ", 169.254.0.0/16, fe80::/10"  # link-local
-        csv += ", 127.0.0.0/8, ::1/128"  # loopback
-
     srcs = [x.strip() for x in csv.split(",") if x.strip()]
+
+    expanded_shorthands = False
+    for shorthand in ("lan", "local", "private", "prvt"):
+        if shorthand in srcs:
+            if not expanded_shorthands:
+                srcs += [
+                    "10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16", "fd00::/8",  # lan
+                    "169.254.0.0/16", "fe80::/10",  # link-local
+                    "127.0.0.0/8, ::1/128",  # loopback
+                ]
+                expanded_shorthands = True
+
+            srcs.remove(shorthand)
+
     if not HAVE_IPV6:
         srcs = [x for x in srcs if ":" not in x]
 


### PR DESCRIPTION
This PR makes it possible to use LAN shorthands when specifying custom CIDR ranges. For example, in the situation where you want to allow connections from both the various local networking places and from Tailscale, you would want to do:

```
xff-src: lan, 100.64.0.0/10
```

but this currently does not work and instead causes copyparty to fail to start.

This is because shorthands are currently detected by comparison to the whole comma-separated string - this PR moves shorthand expansion to after the parsing step to make the above example work as expected.

This PR complies with the DCO; https://developercertificate.org/  

:)