### PR TITLE
Silence missing mainProgram in Nix package

### DIFF
--- a/contrib/package/nix/copyparty/default.nix
+++ b/contrib/package/nix/copyparty/default.nix
@@ -64,4 +64,5 @@ in stdenv.mkDerivation {
       --set PATH '${lib.makeBinPath ([ utillinux ] ++ lib.optional withMediaProcessing ffmpeg)}:$PATH' \
       --add-flags "$out/share/copyparty-sfx.py"
   '';
+  meta.mainProgram = "copyparty";
 }


### PR DESCRIPTION
Previously, when using the Nix package warnings such as:
```
evaluation warning: getExe: Package "copyparty-1.16.15" does not have the meta.mainProgram attribute. We'll assume that the main program has the same name for now, but this behavior is deprecated, because it leads to surprising errors when the assumption does not hold. If the package has a main program, please set `meta.mainProgram` in its definition to make this warning go away. Otherwise, if the package does not have a main program, or if you don't control its definition, use getExe' to specify the name to the program, such as lib.getExe' foo "bar".
```
were emitted, so to silence them this PR adds the `meta.mainProgram` field.

This PR complies with the DCO; https://developercertificate.org/  
