### PR TITLE
Apply custom fonts to up2k parallel uploads input

### DIFF
--- a/copyparty/web/browser.css
+++ b/copyparty/web/browser.css
@@ -2631,7 +2631,6 @@ html.y #bbox-overlay figcaption a {
 	color: var(--fg-max);
 	background: var(--u2-txt-bg);
 	border: 1px solid #777;
-	font-family: var(--font-main), sans-serif;
 	font-size: 1.2em;
 	padding: .15em 0;
 	height: 1.05em;

--- a/copyparty/web/browser.css
+++ b/copyparty/web/browser.css
@@ -2631,6 +2631,7 @@ html.y #bbox-overlay figcaption a {
 	color: var(--fg-max);
 	background: var(--u2-txt-bg);
 	border: 1px solid #777;
+	font-family: var(--font-main), sans-serif;
 	font-size: 1.2em;
 	padding: .15em 0;
 	height: 1.05em;

--- a/copyparty/web/ui.css
+++ b/copyparty/web/ui.css
@@ -381,6 +381,9 @@ html.y .btn:focus {
 	box-shadow: 0 .1em .2em #037 inset;
 	outline: #037 solid .1em;
 }
+input, button {
+	font-family: var(--font-main), sans-serif;
+}
 input[type="submit"] {
 	cursor: pointer;
 }


### PR DESCRIPTION
Currently, the parallel uploads input in the up2k configuration table doesn't use the custom font set in `:root`, as it doesn't inherit from `html`.

On my instance of copyparty, `Tahoma` is used instead on Firefox, and `Arial` on Edge (I assume default sans-serif fonts?) - so this PR fixes that.

This PR complies with the DCO; https://developercertificate.org/  
