### PR TITLE
full lowercase on login button to match the rest of the control panel

### DIFF
--- a/copyparty/web/splash.html
+++ b/copyparty/web/splash.html
@@ -122,7 +122,7 @@
 				<input type="hidden" id="la" name="act" value="login" />
 				<input type="password" id="lp" name="cppwd" placeholder=" password" />
 				<input type="hidden" name="uhash" id="uhash" value="x" />
-				<input type="submit" id="ls" value="Login" />
+				<input type="submit" id="ls" value="login" />
 				{% if chpw %}
 				<a id="x" href="#">change password</a>
 				{% endif %}


### PR DESCRIPTION
the rest of the control panel page is basically all lowercase, so i see no reason the login button shouldn't be, imo it looks better and more unified with no capital L

soz for the small changes per PR :)

![image](https://github.com/user-attachments/assets/1261c255-fa8b-4216-883b-ba3a155afc1c)

This PR complies with the DCO; https://developercertificate.org/  
