### PR TITLE
Don't append .bin to unnamed files

### DIFF
--- a/copyparty/httpcli.py
+++ b/copyparty/httpcli.py
@@ -2100,7 +2100,6 @@ class HttpCli(object):
         suffix = "-{:.6f}-{}".format(time.time(), self.dip())
         nameless = not fn
         if nameless:
-            suffix += ".bin"
             fn = "put" + suffix
 
         params = {"suffix": suffix, "fdir": fdir}


### PR DESCRIPTION
.bin gets appended to all unnamed files uploaded via a PUT request. This happens even if a random file name is specified. .bin files are quite rare so I don't think it's a good extension to slap on to files even if they happen to be binary in nature.

Instead we should just let the file remain extensionless.

To show that your contribution is compatible with the MIT License, please include the following text somewhere in this PR description:  
This PR complies with the DCO; https://developercertificate.org/  
