### PR TITLE
fix: disable use of aliases in nixpkgs

### DIFF
--- a/contrib/package/nix/copyparty/default.nix
+++ b/contrib/package/nix/copyparty/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, makeWrapper, fetchurl, utillinux, python, jinja2, impacket, pyftpdlib, pyopenssl, argon2-cffi, pillow, pyvips, pyzmq, ffmpeg, mutagen,
+{ lib, stdenv, makeWrapper, fetchurl, util-linux, python, jinja2, impacket, pyftpdlib, pyopenssl, argon2-cffi, pillow, pyvips, pyzmq, ffmpeg, mutagen,
 
 # use argon2id-hashed passwords in config files (sha2 is always available)
 withHashedPasswords ? true,
@@ -61,7 +61,7 @@ in stdenv.mkDerivation {
   installPhase = ''
     install -Dm755 $src $out/share/copyparty-sfx.py
     makeWrapper ${pyEnv.interpreter} $out/bin/copyparty \
-      --set PATH '${lib.makeBinPath ([ utillinux ] ++ lib.optional withMediaProcessing ffmpeg)}:$PATH' \
+      --set PATH '${lib.makeBinPath ([ util-linux ] ++ lib.optional withMediaProcessing ffmpeg)}:$PATH' \
       --add-flags "$out/share/copyparty-sfx.py"
   '';
   meta.mainProgram = "copyparty";

--- a/flake.lock
+++ b/flake.lock
@@ -17,16 +17,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1680334310,
-        "narHash": "sha256-ISWz16oGxBhF7wqAxefMPwFag6SlsA9up8muV79V9ck=",
+        "lastModified": 1748162331,
+        "narHash": "sha256-rqc2RKYTxP3tbjA+PB3VMRQNnjesrT0pEofXQTrMsS8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "884e3b68be02ff9d61a042bc9bd9dd2a358f95da",
+        "rev": "7c43f080a7f28b2774f3b3f43234ca11661bf334",
         "type": "github"
       },
       "original": {
         "id": "nixpkgs",
-        "ref": "nixos-22.11",
+        "ref": "nixos-25.05",
         "type": "indirect"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,6 @@
 {
   inputs = {
-    nixpkgs.url = "nixpkgs/nixos-22.11";
+    nixpkgs.url = "nixpkgs/nixos-25.05";
     flake-utils.url = "github:numtide/flake-utils";
   };
 

--- a/flake.nix
+++ b/flake.nix
@@ -17,6 +17,9 @@
       let
         pkgs = import nixpkgs {
           inherit system;
+          config = {
+            allowAliases = false;
+          };
           overlays = [ self.overlays.default ];
         };
       in {


### PR DESCRIPTION
This enables compatibility with users who also disable aliases

The utillinux alias was added in 2020[[1]], which is older than the previous Nixpkgs pin, which means we can safely switch to the non-aliased version.

[1]: https://github.com/NixOS/nixpkgs/blob/3896a0c0e22c8834e8caa297b6e508805c89d1b4/pkgs/top-level/aliases.nix#L1967

While at it I've also bumped the Nixpkgs pin to the latest NixOS release, though I assume all users of the flake will be overriding it anyway so it doesn't matter all that much.

This PR complies with the DCO; https://developercertificate.org/  
