### PR TITLE
Add python-magic to iv and dj docker files

### DIFF
--- a/scripts/docker/Dockerfile.dj
+++ b/scripts/docker/Dockerfile.dj
@@ -15,6 +15,7 @@ RUN     apk add -U !pyc \
             py3-jinja2 py3-argon2-cffi py3-pyzmq py3-pillow \
             py3-pip py3-cffi \
             ffmpeg \
+            py3-magic \
             vips-jxl vips-heif vips-poppler vips-magick \
             py3-numpy fftw libsndfile \
             vamp-sdk vamp-sdk-libs \

--- a/scripts/docker/Dockerfile.iv
+++ b/scripts/docker/Dockerfile.iv
@@ -12,6 +12,7 @@ RUN     apk add -U !pyc \
             py3-jinja2 py3-argon2-cffi py3-pyzmq py3-pillow \
             py3-pip py3-cffi \
             ffmpeg \
+            py3-magic \
             vips-jxl vips-heif vips-poppler vips-magick \
         && apk add -t .bd \
             bash wget gcc g++ make cmake patchelf \


### PR DESCRIPTION
To show that your contribution is compatible with the MIT License, please include the following text somewhere in this PR description:  
This PR complies with the DCO; https://developercertificate.org/  

This dep is needed for the magic feature. It seems to not be included in any docker files. 

I Currently build the docker containers myself as I use this feature. It would be great to have this generally available. 