### PR TITLE
docker: remove deprecated version attr

### DIFF
--- a/docs/examples/docker/basic-docker-compose/docker-compose.yml
+++ b/docs/examples/docker/basic-docker-compose/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
 
   copyparty:


### PR DESCRIPTION
Removed the deprecated version attribute.

Resolves error "the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion" when building using docker-compose.


This PR complies with the DCO; https://developercertificate.org/  
