### PR TITLE
fix various typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ also see [comparison to similar software](./docs/versus.md)
     * ☑ play video files as audio (converted on server)
     * ☑ create and play [m3u8 playlists](#playlists)
   * ☑ image gallery with webm player
-  * ☑ [textfile browser](#textfile-viewer) with syntax hilighting
+  * ☑ [textfile browser](#textfile-viewer) with syntax highlighting
     * ☑ realtime streaming of growing files (logfiles and such)
   * ☑ [thumbnails](#thumbnails)
     * ☑ ...of images using Pillow, pyvips, or FFmpeg
@@ -831,7 +831,7 @@ the up2k UI is the epitome of polished intuitive experiences:
 * `[🔎]` switch between upload and [file-search](#file-search) mode
   * ignore `[🔎]` if you add files by dragging them into the browser
 
-and then theres the tabs below it,
+and then there's the tabs below it,
 * `[ok]` is the files which completed successfully
 * `[ng]` is the ones that failed / got rejected (already exists, ...)
 * `[done]` shows a combined list of `[ok]` and `[ng]`, chronological order
@@ -956,7 +956,7 @@ specify `--shr /foobar` to enable this feature; a toplevel virtual folder named 
 * you can name it whatever, `foobar` is just an example
 * if you're using config files, put `shr: /foobar` inside the `[global]` section instead
 
-users can delete their own shares in the controlpanel, and a list of privileged users (`--shr-adm`) are allowed to see and/or delet any share on the server
+users can delete their own shares in the controlpanel, and a list of privileged users (`--shr-adm`) are allowed to see and/or delete any share on the server
 
 after a share has expired, it remains visible in the controlpanel for `--shr-rt` minutes (default is 1 day), and the owner can revive it by extending the expiration time there
 
@@ -1063,7 +1063,7 @@ plays almost every audio format there is  (if the server has FFmpeg installed fo
 
 the following audio formats are usually always playable, even without FFmpeg: `aac|flac|m4a|mp3|ogg|opus|wav`
 
-some hilights:
+some highlights:
 * OS integration; control playback from your phone's lockscreen ([windows](https://user-images.githubusercontent.com/241032/233213022-298a98ba-721a-4cf1-a3d4-f62634bc53d5.png) // [iOS](https://user-images.githubusercontent.com/241032/142711926-0700be6c-3e31-47b3-9928-53722221f722.png) // [android](https://user-images.githubusercontent.com/241032/233212311-a7368590-08c7-4f9f-a1af-48ccf3f36fad.png))
 * shows the audio waveform in the seekbar
 * not perfectly gapless but can get really close (see settings + eq below); good enough to enjoy gapless albums as intended
@@ -2160,7 +2160,7 @@ when connecting the reverse-proxy to `127.0.0.1` instead (the basic and/or old-f
 
 in summary, `haproxy > caddy > traefik > nginx > apache > lighttpd`, and use uds when possible (traefik does not support it yet)
 
-* if these results are bullshit because my config exampels are bad, please submit corrections!
+* if these results are bullshit because my config examples are bad, please submit corrections!
 
 
 ## permanent cloudflare tunnel

--- a/bin/dbtool.py
+++ b/bin/dbtool.py
@@ -39,7 +39,7 @@ def ls(db):
     print(f"{nfiles} files")
     print(f"{ntags} tags\n")
 
-    print("number of occurences for each tag,")
+    print("number of occurrences for each tag,")
     print(" 'x' = file has no tags")
     print(" 't:mtp' = the mtp flag (file not mtp processed yet)")
     print()

--- a/bin/hooks/notify.py
+++ b/bin/hooks/notify.py
@@ -9,7 +9,7 @@ from plyer import notification
 _ = r"""
 show os notification on upload; works on windows, linux, macos, android
 
-depdencies:
+dependencies:
     windows: python3 -m pip install --user -U plyer
     linux:   python3 -m pip install --user -U plyer
     macos:   python3 -m pip install --user -U plyer pyobjus

--- a/bin/hooks/wget.py
+++ b/bin/hooks/wget.py
@@ -66,7 +66,7 @@ def main():
     try:
         sp.check_call(cmd)
     except:
-        t = "-- FAILED TO DONWLOAD " + name
+        t = "-- FAILED TO DOWNLOAD " + name
         print(f"{t}\n", end="")
         open(t, "wb").close()
 

--- a/bin/mtag/guestbook-read.py
+++ b/bin/mtag/guestbook-read.py
@@ -7,7 +7,7 @@ example copyparty config to use this:
   --urlform save,get -vsrv/hello:hello:w:c,e2ts,mtp=guestbook=t10,ad,p,bin/mtag/guestbook-read.py:mte=+guestbook
 
 explained:
-  for realpath srv/hello (served at /hello), write-only for eveyrone,
+  for realpath srv/hello (served at /hello), write-only for everyone,
   enable file analysis on upload (e2ts),
   use mtp plugin "bin/mtag/guestbook-read.py" to provide metadata tag "guestbook",
   do this on all uploads regardless of extension,

--- a/bin/mtag/guestbook.py
+++ b/bin/mtag/guestbook.py
@@ -11,7 +11,7 @@ example copyparty config to use this:
   --urlform save,get -vsrv/hello:hello:w:c,e2ts,mtp=xgb=ebin,t10,ad,p,bin/mtag/guestbook.py:mte=+xgb
 
 explained:
-  for realpath srv/hello (served at /hello),write-only for eveyrone,
+  for realpath srv/hello (served at /hello),write-only for everyone,
   enable file analysis on upload (e2ts),
   use mtp plugin "bin/mtag/guestbook.py" to provide metadata tag "xgb",
   do this on all uploads with the file extension "bin",

--- a/bin/mtag/very-bad-idea.py
+++ b/bin/mtag/very-bad-idea.py
@@ -151,7 +151,7 @@ def open_url(txt):
         for _ in range(20):
             sp.call(["xdotool", "key", "ctrl+w"])  # closes the open tab correctly
     # else:
-    #    sp.call(["xdotool", "getactivewindow", "windowminimize"])  # minimizes the focused windo
+    #    sp.call(["xdotool", "getactivewindow", "windowminimize"])  # minimizes the focused window
 
     # mpv is probably smart enough to use streamlink automatically
     if try_mpv(txt):

--- a/bin/mtag/wget.py
+++ b/bin/mtag/wget.py
@@ -84,7 +84,7 @@ def main():
         #   on success, delete the .bin file which contains the URL
         os.unlink(fp)
     except:
-        open("-- FAILED TO DONWLOAD " + name, "wb").close()
+        open("-- FAILED TO DOWNLOAD " + name, "wb").close()
 
     os.unlink(tfn)
     print(url)

--- a/contrib/nginx/copyparty.conf
+++ b/contrib/nginx/copyparty.conf
@@ -31,7 +31,7 @@
 # generate the list of permitted IP ranges like so:
 #   (curl -s https://www.cloudflare.com/ips-v{4,6} | sed 's/^/allow /; s/$/;/'; echo; echo "deny all;") > /etc/nginx/cloudflare-only.conf
 #
-# and then enable it below by uncomenting the cloudflare-only.conf line
+# and then enable it below by uncommenting the cloudflare-only.conf line
 #
 # ======================================================================
 

--- a/contrib/plugins/meadup.js
+++ b/contrib/plugins/meadup.js
@@ -11,7 +11,7 @@ var hambagas = [
     "https://www.youtube.com/watch?v=pFA3KGp4GuU"
 ];
 
-// keybaord,
+// keyboard,
 //   onscreen keyboard by @steinuil
 function initKeybaord(BASE_URL, HAMBAGA, consoleLog, consoleError) {
     document.querySelector('.keybaord-container').innerHTML = `
@@ -373,7 +373,7 @@ function initKeybaord(BASE_URL, HAMBAGA, consoleLog, consoleError) {
 }
 
 
-// keybaord integration
+// keyboard integration
 (function () {
     var o = mknod('div');
     clmod(o, 'keybaord-container', 1);

--- a/contrib/plugins/meadup.js
+++ b/contrib/plugins/meadup.js
@@ -13,278 +13,278 @@ var hambagas = [
 
 // keyboard,
 //   onscreen keyboard by @steinuil
-function initKeybaord(BASE_URL, HAMBAGA, consoleLog, consoleError) {
-    document.querySelector('.keybaord-container').innerHTML = `
-      <div class="keybaord-body">
-        <div class="keybaord-row keybaord-row-1">
-          <div class="keybaord-key" data-keybaord-key="Escape">
+function initKeyboard(BASE_URL, HAMBAGA, consoleLog, consoleError) {
+    document.querySelector('.keyboard-container').innerHTML = `
+      <div class="keyboard-body">
+        <div class="keyboard-row keyboard-row-1">
+          <div class="keyboard-key" data-keyboard-key="Escape">
             esc
           </div>
-          <div class="keybaord-key" data-keybaord-key="F1">
+          <div class="keyboard-key" data-keyboard-key="F1">
             F1
           </div>
-          <div class="keybaord-key" data-keybaord-key="F2">
+          <div class="keyboard-key" data-keyboard-key="F2">
             F2
           </div>
-          <div class="keybaord-key" data-keybaord-key="F3">
+          <div class="keyboard-key" data-keyboard-key="F3">
             F3
           </div>
-          <div class="keybaord-key" data-keybaord-key="F4">
+          <div class="keyboard-key" data-keyboard-key="F4">
             F4
           </div>
-          <div class="keybaord-key" data-keybaord-key="F5">
+          <div class="keyboard-key" data-keyboard-key="F5">
             F5
           </div>
-          <div class="keybaord-key" data-keybaord-key="F6">
+          <div class="keyboard-key" data-keyboard-key="F6">
             F6
           </div>
-          <div class="keybaord-key" data-keybaord-key="F7">
+          <div class="keyboard-key" data-keyboard-key="F7">
             F7
           </div>
-          <div class="keybaord-key" data-keybaord-key="F8">
+          <div class="keyboard-key" data-keyboard-key="F8">
             F8
           </div>
-          <div class="keybaord-key" data-keybaord-key="F9">
+          <div class="keyboard-key" data-keyboard-key="F9">
             F9
           </div>
-          <div class="keybaord-key" data-keybaord-key="F10">
+          <div class="keyboard-key" data-keyboard-key="F10">
             F10
           </div>
-          <div class="keybaord-key" data-keybaord-key="F11">
+          <div class="keyboard-key" data-keyboard-key="F11">
             F11
           </div>
-          <div class="keybaord-key" data-keybaord-key="F12">
+          <div class="keyboard-key" data-keyboard-key="F12">
             F12
           </div>
-          <div class="keybaord-key" data-keybaord-key="Insert">
+          <div class="keyboard-key" data-keyboard-key="Insert">
             ins
           </div>
-          <div class="keybaord-key" data-keybaord-key="Delete">
+          <div class="keyboard-key" data-keyboard-key="Delete">
             del
           </div>
         </div>
-        <div class="keybaord-row keybaord-row-2">
-          <div class="keybaord-key" data-keybaord-key="\`">
+        <div class="keyboard-row keyboard-row-2">
+          <div class="keyboard-key" data-keyboard-key="\`">
             \`
           </div>
-          <div class="keybaord-key" data-keybaord-key="1">
+          <div class="keyboard-key" data-keyboard-key="1">
             1
           </div>
-          <div class="keybaord-key" data-keybaord-key="2">
+          <div class="keyboard-key" data-keyboard-key="2">
             2
           </div>
-          <div class="keybaord-key" data-keybaord-key="3">
+          <div class="keyboard-key" data-keyboard-key="3">
             3
           </div>
-          <div class="keybaord-key" data-keybaord-key="4">
+          <div class="keyboard-key" data-keyboard-key="4">
             4
           </div>
-          <div class="keybaord-key" data-keybaord-key="5">
+          <div class="keyboard-key" data-keyboard-key="5">
             5
           </div>
-          <div class="keybaord-key" data-keybaord-key="6">
+          <div class="keyboard-key" data-keyboard-key="6">
             6
           </div>
-          <div class="keybaord-key" data-keybaord-key="7">
+          <div class="keyboard-key" data-keyboard-key="7">
             7
           </div>
-          <div class="keybaord-key" data-keybaord-key="8">
+          <div class="keyboard-key" data-keyboard-key="8">
             8
           </div>
-          <div class="keybaord-key" data-keybaord-key="9">
+          <div class="keyboard-key" data-keyboard-key="9">
             9
           </div>
-          <div class="keybaord-key" data-keybaord-key="0">
+          <div class="keyboard-key" data-keyboard-key="0">
             0
           </div>
-          <div class="keybaord-key" data-keybaord-key="-">
+          <div class="keyboard-key" data-keyboard-key="-">
             -
           </div>
-          <div class="keybaord-key" data-keybaord-key="=">
+          <div class="keyboard-key" data-keyboard-key="=">
             =
           </div>
-          <div class="keybaord-key keybaord-backspace" data-keybaord-key="BackSpace">
+          <div class="keyboard-key keyboard-backspace" data-keyboard-key="BackSpace">
             backspace
           </div>
         </div>
-        <div class="keybaord-row keybaord-row-3">
-          <div class="keybaord-key keybaord-tab" data-keybaord-key="Tab">
+        <div class="keyboard-row keyboard-row-3">
+          <div class="keyboard-key keyboard-tab" data-keyboard-key="Tab">
             tab
           </div>
-          <div class="keybaord-key" data-keybaord-key="q">
+          <div class="keyboard-key" data-keyboard-key="q">
             q
           </div>
-          <div class="keybaord-key" data-keybaord-key="w">
+          <div class="keyboard-key" data-keyboard-key="w">
             w
           </div>
-          <div class="keybaord-key" data-keybaord-key="e">
+          <div class="keyboard-key" data-keyboard-key="e">
             e
           </div>
-          <div class="keybaord-key" data-keybaord-key="r">
+          <div class="keyboard-key" data-keyboard-key="r">
             r
           </div>
-          <div class="keybaord-key" data-keybaord-key="t">
+          <div class="keyboard-key" data-keyboard-key="t">
             t
           </div>
-          <div class="keybaord-key" data-keybaord-key="y">
+          <div class="keyboard-key" data-keyboard-key="y">
             y
           </div>
-          <div class="keybaord-key" data-keybaord-key="u">
+          <div class="keyboard-key" data-keyboard-key="u">
             u
           </div>
-          <div class="keybaord-key" data-keybaord-key="i">
+          <div class="keyboard-key" data-keyboard-key="i">
             i
           </div>
-          <div class="keybaord-key" data-keybaord-key="o">
+          <div class="keyboard-key" data-keyboard-key="o">
             o
           </div>
-          <div class="keybaord-key" data-keybaord-key="p">
+          <div class="keyboard-key" data-keyboard-key="p">
             p
           </div>
-          <div class="keybaord-key" data-keybaord-key="[">
+          <div class="keyboard-key" data-keyboard-key="[">
             [
           </div>
-          <div class="keybaord-key" data-keybaord-key="]">
+          <div class="keyboard-key" data-keyboard-key="]">
             ]
           </div>
-          <div class="keybaord-key keybaord-enter" data-keybaord-key="Return">
+          <div class="keyboard-key keyboard-enter" data-keyboard-key="Return">
             enter
           </div>
         </div>
-        <div class="keybaord-row keybaord-row-4">
-          <div class="keybaord-key keybaord-capslock" data-keybaord-key="HAMBAGA">
+        <div class="keyboard-row keyboard-row-4">
+          <div class="keyboard-key keyboard-capslock" data-keyboard-key="HAMBAGA">
             🍔
           </div>
-          <div class="keybaord-key" data-keybaord-key="a">
+          <div class="keyboard-key" data-keyboard-key="a">
             a
           </div>
-          <div class="keybaord-key" data-keybaord-key="s">
+          <div class="keyboard-key" data-keyboard-key="s">
             s
           </div>
-          <div class="keybaord-key" data-keybaord-key="d">
+          <div class="keyboard-key" data-keyboard-key="d">
             d
           </div>
-          <div class="keybaord-key" data-keybaord-key="f">
+          <div class="keyboard-key" data-keyboard-key="f">
             f
           </div>
-          <div class="keybaord-key" data-keybaord-key="g">
+          <div class="keyboard-key" data-keyboard-key="g">
             g
           </div>
-          <div class="keybaord-key" data-keybaord-key="h">
+          <div class="keyboard-key" data-keyboard-key="h">
             h
           </div>
-          <div class="keybaord-key" data-keybaord-key="j">
+          <div class="keyboard-key" data-keyboard-key="j">
             j
           </div>
-          <div class="keybaord-key" data-keybaord-key="k">
+          <div class="keyboard-key" data-keyboard-key="k">
             k
           </div>
-          <div class="keybaord-key" data-keybaord-key="l">
+          <div class="keyboard-key" data-keyboard-key="l">
             l
           </div>
-          <div class="keybaord-key" data-keybaord-key=";">
+          <div class="keyboard-key" data-keyboard-key=";">
             ;
           </div>
-          <div class="keybaord-key" data-keybaord-key="'">
+          <div class="keyboard-key" data-keyboard-key="'">
             '
           </div>
-          <div class="keybaord-key keybaord-backslash" data-keybaord-key="\\">
+          <div class="keyboard-key keyboard-backslash" data-keyboard-key="\\">
             \\
           </div>
         </div>
-        <div class="keybaord-row keybaord-row-5">
-          <div class="keybaord-key keybaord-lshift" data-keybaord-key="Shift_L">
+        <div class="keyboard-row keyboard-row-5">
+          <div class="keyboard-key keyboard-lshift" data-keyboard-key="Shift_L">
             shift
           </div>
-          <div class="keybaord-key" data-keybaord-key="\\">
+          <div class="keyboard-key" data-keyboard-key="\\">
             \\
           </div>
-          <div class="keybaord-key" data-keybaord-key="z">
+          <div class="keyboard-key" data-keyboard-key="z">
             z
           </div>
-          <div class="keybaord-key" data-keybaord-key="x">
+          <div class="keyboard-key" data-keyboard-key="x">
             x
           </div>
-          <div class="keybaord-key" data-keybaord-key="c">
+          <div class="keyboard-key" data-keyboard-key="c">
             c
           </div>
-          <div class="keybaord-key" data-keybaord-key="v">
+          <div class="keyboard-key" data-keyboard-key="v">
             v
           </div>
-          <div class="keybaord-key" data-keybaord-key="b">
+          <div class="keyboard-key" data-keyboard-key="b">
             b
           </div>
-          <div class="keybaord-key" data-keybaord-key="n">
+          <div class="keyboard-key" data-keyboard-key="n">
             n
           </div>
-          <div class="keybaord-key" data-keybaord-key="m">
+          <div class="keyboard-key" data-keyboard-key="m">
             m
           </div>
-          <div class="keybaord-key" data-keybaord-key=",">
+          <div class="keyboard-key" data-keyboard-key=",">
             ,
           </div>
-          <div class="keybaord-key" data-keybaord-key=".">
+          <div class="keyboard-key" data-keyboard-key=".">
             .
           </div>
-          <div class="keybaord-key" data-keybaord-key="/">
+          <div class="keyboard-key" data-keyboard-key="/">
             /
           </div>
-          <div class="keybaord-key keybaord-rshift" data-keybaord-key="Shift_R">
+          <div class="keyboard-key keyboard-rshift" data-keyboard-key="Shift_R">
             shift
           </div>
         </div>
-        <div class="keybaord-row keybaord-row-6">
-          <div class="keybaord-key keybaord-lctrl" data-keybaord-key="Control_L">
+        <div class="keyboard-row keyboard-row-6">
+          <div class="keyboard-key keyboard-lctrl" data-keyboard-key="Control_L">
             ctrl
           </div>
-          <div class="keybaord-key keybaord-super" data-keybaord-key="Meta_L">
+          <div class="keyboard-key keyboard-super" data-keyboard-key="Meta_L">
             win
           </div>
-          <div class="keybaord-key keybaord-alt" data-keybaord-key="Alt_L">
+          <div class="keyboard-key keyboard-alt" data-keyboard-key="Alt_L">
             alt
           </div>
-          <div class="keybaord-key keybaord-spacebar" data-keybaord-key="space">
+          <div class="keyboard-key keyboard-spacebar" data-keyboard-key="space">
             space
           </div>
-          <div class="keybaord-key keybaord-altgr" data-keybaord-key="Alt_R">
+          <div class="keyboard-key keyboard-altgr" data-keyboard-key="Alt_R">
             altgr
           </div>
-          <div class="keybaord-key keybaord-what" data-keybaord-key="Menu">
+          <div class="keyboard-key keyboard-what" data-keyboard-key="Menu">
             menu
           </div>
-          <div class="keybaord-key keybaord-rctrl" data-keybaord-key="Control_R">
+          <div class="keyboard-key keyboard-rctrl" data-keyboard-key="Control_R">
             ctrl
           </div>
         </div>
-        <div class="keybaord-row">
-          <div class="keybaord-key" data-keybaord-key="XF86AudioLowerVolume">
+        <div class="keyboard-row">
+          <div class="keyboard-key" data-keyboard-key="XF86AudioLowerVolume">
             🔉
           </div>
-          <div class="keybaord-key" data-keybaord-key="XF86AudioRaiseVolume">
+          <div class="keyboard-key" data-keyboard-key="XF86AudioRaiseVolume">
             🔊
           </div>
-          <div class="keybaord-key" data-keybaord-key="Left">
+          <div class="keyboard-key" data-keyboard-key="Left">
             ⬅️
           </div>
-          <div class="keybaord-key" data-keybaord-key="Down">
+          <div class="keyboard-key" data-keyboard-key="Down">
             ⬇️
           </div>
-          <div class="keybaord-key" data-keybaord-key="Up">
+          <div class="keyboard-key" data-keyboard-key="Up">
             ⬆️
           </div>
-          <div class="keybaord-key" data-keybaord-key="Right">
+          <div class="keyboard-key" data-keyboard-key="Right">
             ➡️
           </div>
-          <div class="keybaord-key" data-keybaord-key="Page_Up">
+          <div class="keyboard-key" data-keyboard-key="Page_Up">
             PgUp
           </div>
-          <div class="keybaord-key" data-keybaord-key="Page_Down">
+          <div class="keyboard-key" data-keyboard-key="Page_Down">
             PgDn
           </div>
-          <div class="keybaord-key" data-keybaord-key="Home">
+          <div class="keyboard-key" data-keyboard-key="Home">
             🏠
           </div>
-          <div class="keybaord-key" data-keybaord-key="End">
+          <div class="keyboard-key" data-keyboard-key="End">
             End
           </div>
         </div>
@@ -307,9 +307,9 @@ function initKeybaord(BASE_URL, HAMBAGA, consoleLog, consoleError) {
             (err) => consoleError(err)
         );
     }
-    const MODIFIER_ON_CLASS = "keybaord-modifier-on";
-    const KEY_DATASET = "data-keybaord-key";
-    const KEY_CLASS = "keybaord-key";
+    const MODIFIER_ON_CLASS = "keyboard-modifier-on";
+    const KEY_DATASET = "data-keyboard-key";
+    const KEY_CLASS = "keyboard-key";
 
     const modifiers = new Set()
 
@@ -338,7 +338,7 @@ function initKeybaord(BASE_URL, HAMBAGA, consoleLog, consoleError) {
     }
 
     Array.from(document.querySelectorAll("." + KEY_CLASS)).forEach((button) => {
-        const key = button.dataset.keybaordKey;
+        const key = button.dataset.keyboardKey;
 
         button.addEventListener("click", (ev) => {
             switch (key) {
@@ -376,22 +376,22 @@ function initKeybaord(BASE_URL, HAMBAGA, consoleLog, consoleError) {
 // keyboard integration
 (function () {
     var o = mknod('div');
-    clmod(o, 'keybaord-container', 1);
+    clmod(o, 'keyboard-container', 1);
     ebi('op_msg').appendChild(o);
 
     o = mknod('style');
     o.innerHTML = `
-.keybaord-body {
+.keyboard-body {
 	display: flex;
 	flex-flow: column nowrap;
     margin: .6em 0;
 }
 
-.keybaord-row {
+.keyboard-row {
 	display: flex;
 }
 
-.keybaord-key {
+.keyboard-key {
 	border: 1px solid rgba(128,128,128,0.2);
 	width: 41px;
 	height: 40px;
@@ -401,73 +401,73 @@ function initKeybaord(BASE_URL, HAMBAGA, consoleLog, consoleError) {
 	align-items: center;
 }
 
-.keybaord-key:active {
+.keyboard-key:active {
 	background-color: lightgrey;
 }
 
-.keybaord-key.keybaord-modifier-on {
+.keyboard-key.keyboard-modifier-on {
 	background-color: lightblue;
 }
 
-.keybaord-key.keybaord-backspace {
+.keyboard-key.keyboard-backspace {
 	width: 82px;
 }
 
-.keybaord-key.keybaord-tab {
+.keyboard-key.keyboard-tab {
 	width: 55px;
 }
 
-.keybaord-key.keybaord-enter {
+.keyboard-key.keyboard-enter {
 	width: 69px;
 }
 
-.keybaord-key.keybaord-capslock {
+.keyboard-key.keyboard-capslock {
 	width: 80px;
 }
 
-.keybaord-key.keybaord-backslash {
+.keyboard-key.keyboard-backslash {
 	width: 88px;
 }
 
-.keybaord-key.keybaord-lshift {
+.keyboard-key.keyboard-lshift {
 	width: 65px;
 }
 
-.keybaord-key.keybaord-rshift {
+.keyboard-key.keyboard-rshift {
 	width: 103px;
 }
 
-.keybaord-key.keybaord-lctrl {
+.keyboard-key.keyboard-lctrl {
 	width: 55px;
 }
 
-.keybaord-key.keybaord-super {
+.keyboard-key.keyboard-super {
 	width: 55px;
 }
 
-.keybaord-key.keybaord-alt {
+.keyboard-key.keyboard-alt {
 	width: 55px;
 }
 
-.keybaord-key.keybaord-altgr {
+.keyboard-key.keyboard-altgr {
 	width: 55px;
 }
 
-.keybaord-key.keybaord-what {
+.keyboard-key.keyboard-what {
 	width: 55px;
 }
 
-.keybaord-key.keybaord-rctrl {
+.keyboard-key.keyboard-rctrl {
 	width: 55px;
 }
 
-.keybaord-key.keybaord-spacebar {
+.keyboard-key.keyboard-spacebar {
 	width: 302px;
 }
 `;
     document.head.appendChild(o);
 
-    initKeybaord('/', hambagas,
+    initKeyboard('/', hambagas,
         (msg) => { toast.inf(2, msg.toString()) },
         (msg) => { toast.err(30, msg.toString()) });
 })();

--- a/copyparty/__main__.py
+++ b/copyparty/__main__.py
@@ -786,7 +786,7 @@ def get_sects():
              \033[36mc0\033[35m show all process output (default)
              \033[36mc1\033[35m show only stderr
              \033[36mc2\033[35m show only stdout
-             \033[36mc3\033[35m mute all process otput
+             \033[36mc3\033[35m mute all process output
             \033[0m
             examples:
 

--- a/copyparty/stolen/ifaddr/_shared.py
+++ b/copyparty/stolen/ifaddr/_shared.py
@@ -41,7 +41,7 @@ class Adapter(object):
         #: `{846EE342-7039-11DE-9D20-806E6F6E6963}`.
         self.name = name
 
-        #: Human readable name of the adpater. On Linux this
+        #: Human readable name of the adapter. On Linux this
         #: is currently the same as :attr:`name`. On Windows
         #: this is the name of the device.
         self.nice_name = nice_name

--- a/copyparty/web/browser.js
+++ b/copyparty/web/browser.js
@@ -329,7 +329,7 @@ var Ls = {
 		"mm_enet": "Your internet connection is wonky",
 		"mm_edec": "This file is supposedly corrupted??",
 		"mm_esupp": "Your browser does not understand this audio format",
-		"mm_eunk": "Unknown Errol",
+		"mm_eunk": "Unknown Error",
 		"mm_e404": "Could not play audio; error 404: File not found.",
 		"mm_e403": "Could not play audio; error 403: Access denied.\n\nTry pressing F5 to reload, maybe you got logged out",
 		"mm_e500": "Could not play audio; error 500: Check server logs.",

--- a/copyparty/web/md.js
+++ b/copyparty/web/md.js
@@ -422,7 +422,7 @@ function init_toc() {
         }
     }
 
-    // hilight the correct toc items + scroll into view
+    // highlight the correct toc items + scroll into view
     function freshen_toclist() {
         if (anchors.length == 0)
             return;

--- a/copyparty/web/up2k.js
+++ b/copyparty/web/up2k.js
@@ -50,7 +50,7 @@ catch (ex) {
     }
     catch (ex) {
         console.log('up2k init failed:', ex);
-        toast.err(10, 'could not initialze up2k\n\n' + basenames(ex));
+        toast.err(10, 'could not initialize up2k\n\n' + basenames(ex));
     }
 }
 treectl.onscroll();

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -592,7 +592,7 @@ get the party going anywhere, anytime, no OS required! [download flashdrive imag
 
 * option to specify max-size for download-as-zip/tar 494179bd 0a33336d
   * either the total download size (`--zipmaxs 500M`), and/or max number of files (`--zipmaxn 9k`)
-  * applies to all uesrs by default; can also ignore limits for authorized users (`--zipmaxu`)
+  * applies to all users by default; can also ignore limits for authorized users (`--zipmaxu`)
   * errormessage can be customized with `--zipmaxt "winter is coming... but this download isn't"`
 * [appledoubles](https://a.ocv.me/pub/stuff/?doc=appledoubles-and-friends.txt) are detected and skipped when uploading with the browser-UI 78208405
 * IdP-volumes can be filtered by group 9c2c4237
@@ -1047,7 +1047,7 @@ this release includes a build of [copyparty-winpe64.exe](https://github.com/9001
 * webdav: support listing unmapped root with infinite recursion (Depth:0) 21a3f369
 * embed current sort config into media URLs (gallery/music) 0f257c93 4cfdc4c5 01670827
   * ensures that anyone clicking your link will see the files in the same order as you
-  * can be confgured serverside (`--hsortn`, volflag `hsortn`) and clientside (`#sort` in settings)
+  * can be configured serverside (`--hsortn`, volflag `hsortn`) and clientside (`#sort` in settings)
 * URL and UI options to disable checksum calculation of PUT, bup, basic uploads c5a000d2
   * also allows [choosing either md5, sha1, sha256, or blake2](https://github.com/9001/copyparty/blob/hovudstraum/docs/devnotes.md#write) instead of the default sha512
   * can give uploads a nice speed boost when copyparty is running on a potato
@@ -2240,7 +2240,7 @@ probably last release before v1.10 (IdP), please watch warmly
 * now possible to POST files without having to set the `act: bput` multipart field 9bc09ce9
   * mainly to support [igloo irc](https://github.com/9001/copyparty#client-examples) and other simplistic upload clients
 * try to point the linux oom-killer at FFmpeg so it doesn't kill innocent processes instead dc8e621d
-  * only works if copyparty has acces to /proc, so not in prisonparty, and maybe not in docker (todo)
+  * only works if copyparty has access to /proc, so not in prisonparty, and maybe not in docker (todo)
 * UX:
   * do another search immediately if a search-filter gets unchecked a4239a46
   * several ie11 fixes (keyboard hotkeys and a working text editor) 2fd2c6b9
@@ -3710,7 +3710,7 @@ named after [that other thing](https://en.wikipedia.org/wiki/Tower_of_Babel), no
 * display a server [qr-code](https://github.com/9001/copyparty#qr-code) [(screenshot)](https://user-images.githubusercontent.com/241032/194728533-6f00849b-c6ac-43c6-9359-83e454d11e00.png) on startup
   * primarily for running copyparty on a phone and accessing it from another
   * optionally specify a path or password with `--qrl lootbox/?pw=hunter2`
-  * uses the server's exteral ip (default route) unless `--qri` specifies a domain / ip-prefix
+  * uses the server's external ip (default route) unless `--qri` specifies a domain / ip-prefix
   * classic cp437 `▄` `▀` for space efficiency; some misbehaving terminals / fonts need `--qrz 2`
 * new permission `G` returns the filekey of uploaded files for users without read-access
   * when combined with permission `w` and volflag `fk`, uploaded files will not be accessible unless the filekey is provided in the url, and `G` provides the filekey to the uploader unlike `g`
@@ -4938,7 +4938,7 @@ for future releases, you can use a script to automatically grab the latest sfx a
 * latest gzip edition of the sfx: [v0.11.18](https://github.com/9001/copyparty/releases/tag/v0.11.18)
 
 ## bugfixes
-* currently-playing song didn't hilight correctly
+* currently-playing song didn't highlight correctly
 
 
 
@@ -4990,7 +4990,7 @@ thx to @Bevinsky and @icxes for the ux suggestions
   * and `?raw` POST without content-type is now allowed
 * file-listing is refreshed when all up2k uploads complete
 * new option `--ign-ebind` to continue startup even if one of the IPs / ports couldn't be listened on
-* new option `--ign-ebind-all` to run even if copyparty can't receieve any connections at all
+* new option `--ign-ebind-all` to run even if copyparty can't receive any connections at all
   * maybe useful for monitoring folders and hashing new files on a timer or something
 
 ## bugfixes
@@ -6304,7 +6304,7 @@ unless the upload was paused for 6 hours or more, it can probably be resumed by 
 
 ## new features suggested by kipu
 * pause uploads by setting `parallel uploads` to `0`
-* increase max `parallel uploads` to 16 (using +/- buttons) and 64 (by manual text entry) to accomodate sad american internet connections
+* increase max `parallel uploads` to 16 (using +/- buttons) and 64 (by manual text entry) to accommodate sad american internet connections
 * also look for `cover.jpg` and `cover.png` as folder thumbnails by default, adjustable with `--th-covers`
 * change the description in the sfx so the corruption warning is the first plaintext you see
 
@@ -6458,7 +6458,7 @@ reason: [v0.11.12](https://github.com/9001/copyparty/releases/tag/v0.11.12) chan
 
 ## new features
 * much faster filesearch in chrome
-* skip hidden colums in the /np text
+* skip hidden columns in the /np text
 * support cygpaths when pointing to mtag tools
 
 ## bugfixes
@@ -7469,7 +7469,7 @@ valvrave-stop.jpg
 ▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀  
 # 2020-1117-2258  `v0.5.4`  edovprim
 
-(get it? becasue reverse proxy haha)
+(get it? because reverse proxy haha)
 
 * reverse-proxy support
 * filetype column in the browser

--- a/docs/devnotes.md
+++ b/docs/devnotes.md
@@ -328,7 +328,7 @@ if you don't need all the features, you can repack the sfx and save a bunch of s
 
 the features you can opt to drop are
 * `cm`/easymde, the "fancy" markdown editor, saves ~89k
-* `hl`, prism, the syntax hilighter, saves ~41k
+* `hl`, prism, the syntax highlighter, saves ~41k
 * `fnt`, source-code-pro, the monospace font, saves ~9k
 
 for the `re`pack to work, first run one of the sfx'es once to unpack it

--- a/docs/examples/docker/idp-authelia-traefik/README.md
+++ b/docs/examples/docker/idp-authelia-traefik/README.md
@@ -47,4 +47,4 @@ currently **not optimal,** at least when compared to running the python sfx outs
 
 authelia is behaving strangely, handling 340 requests per second for a while, but then it suddenly drops to 75 and stays there...
 
-I'm assuming all of the performance issues is due to a misconfiguration of authelia/traefik/docker on my end, but I don't relly know where to start
+I'm assuming all of the performance issues is due to a misconfiguration of authelia/traefik/docker on my end, but I don't really know where to start

--- a/docs/notes.sh
+++ b/docs/notes.sh
@@ -71,7 +71,7 @@ avg() { awk 'function pr(ncsz) {if (nsmp>0) {printf "%3s %s\n", csz, sum/nsmp} c
 python3 -um copyparty -nw -v srv::rw -i 127.0.0.1 2>&1 | tee log 
 cat log | awk '!/"purl"/{next} {s=$1;sub(/[^m]+m/,"");gsub(/:/," ");t=60*(60*$1+$2)+$3} t<p{t+=86400} !a{a=t;sa=s} {b=t;sb=s} END {print b-a,sa,sb}'
 
-# or if the client youre measuring dies for ~15sec every once ina while and you wanna filter those out,
+# or if the client you're measuring dies for ~15sec every once ina while and you wanna filter those out,
 cat log | awk '!/"purl"/{next} {s=$1;sub(/[^m]+m/,"");gsub(/:/," ");t=60*(60*$1+$2)+$3} t<p{t+=86400} !p{a=t;p=t;r=0;next} t-p>1{printf "%.3f += %.3f - %.3f  (%.3f)  # %.3f -> %.3f\n",r,p,a,p-a,p,t;r+=p-a;a=t} {p=t} END {print r+p-a}'
 
 

--- a/docs/up2k.txt
+++ b/docs/up2k.txt
@@ -17,7 +17,7 @@ server creates session id and replies with the same json:
 		secretsalt, name, size, *hash
 	]))[:32].replace('+','-').replace('/','_')
 
-cilent uploads each chunk:
+client uploads each chunk:
 POST application/octet-stream
 X-Up2k-Hash: fUGShzwcSAmw5IbQ3y_2TUrI8a89LYQO-kW0o0rRcU0
 X-Up2k-Wark: CVNt9EYhgTFHU3xiK6gL-0ciJFopshvo

--- a/docs/versus.md
+++ b/docs/versus.md
@@ -82,9 +82,9 @@ currently up to date with [awesome-selfhosted](https://github.com/awesome-selfho
 <&Kethsar> copyparty is very much bloat ed, so yeah
 ```
 
-the table headers in the matrixes below are the different softwares, with a quick review of each software in the next section
+the table headers in the matrixes below are the different software, with a quick review of each software in the next section
 
-the softwares,
+the software,
 * `a` = [copyparty](https://github.com/9001/copyparty)
 * `b` = [hfs2](https://github.com/rejetto/hfs2/) 🔥
 * `c` = [hfs3](https://rejetto.com/hfs/)
@@ -99,7 +99,7 @@ the softwares,
 * `l` = [sftpgo](https://github.com/drakkan/sftpgo)
 * `m` = [arozos](https://github.com/tobychui/arozos)
 
-some softwares not in the matrixes,
+some software not in the matrixes,
 * [updog](#updog)
 * [goshs](#goshs)
 * [gimme-that](#gimmethat)
@@ -242,7 +242,7 @@ symbol legend,
   * you can successfully play `$'\355\221'` with mpv through mounting a remote copyparty server with rclone, pog
 * `a`/copyparty remarks:
   * extremely minimal samba/cifs server
-  * netscape 4 / ie6 support is mostly listed as a joke altho some people have actually found it useful ([ie4 tho](https://user-images.githubusercontent.com/241032/118192791-fb31fe00-b446-11eb-9647-898ea8efc1f7.png))
+  * netscape 4 / ie6 support is mostly listed as a joke although some people have actually found it useful ([ie4 tho](https://user-images.githubusercontent.com/241032/118192791-fb31fe00-b446-11eb-9647-898ea8efc1f7.png))
 * `l`/sftpgo translates mojibake filenames into valid utf-8 (information loss)
 * `m`/arozos has readonly-support for older browsers; no uploading
 
@@ -575,7 +575,7 @@ symbol legend,
 * ✅ file tags; file discussions!?
 * ✅ video transcoding
 * ✅ unzip uploaded archives
-* ✅ IDE with syntax hilighting
+* ✅ IDE with syntax highlighting
 * ✅ wysiwyg editor for openoffice files
 
 ## [filebrowser](https://github.com/filebrowser/filebrowser)

--- a/scripts/copyparty-repack.sh
+++ b/scripts/copyparty-repack.sh
@@ -27,7 +27,7 @@ set -e
 # 270004  copyparty-extras/sfx-lite/copyparty-sfx.py
 # 293159  copyparty-extras/sfx-lite/copyparty-sfx-gz.py
 #           `- also removed the codemirror markdown editor
-#              and the text-viewer syntax hilighting,
+#              and the text-viewer syntax highlighting,
 #              only essential features remaining
 #
 # 646297  copyparty-extras/copyparty-1.0.14.tar.gz

--- a/scripts/docker/README.md
+++ b/scripts/docker/README.md
@@ -1,4 +1,4 @@
-copyparty is availabe in these repos:
+copyparty is available in these repos:
 * https://hub.docker.com/u/copyparty
 * https://github.com/9001?tab=packages&repo_name=copyparty
 

--- a/scripts/docker/make.sh
+++ b/scripts/docker/make.sh
@@ -115,7 +115,7 @@ filt=
             ) 2> >(tee $a.err | sed "s/^/$aa:/" >&2) > >(tee $a.out | sed "s/^/$aa:/") &
         done
         [ -e err ] && {
-            echo somethign died,
+            echo something died,
             cat err
             pkill -P $$
             exit 1
@@ -126,7 +126,7 @@ filt=
     done
     wait
     [ -e err ] && {
-        echo somethign died,
+        echo something died,
         cat err
         pkill -P $$
         exit 1

--- a/scripts/make-sfx.sh
+++ b/scripts/make-sfx.sh
@@ -41,7 +41,7 @@ help() { exec cat <<'EOF'
 # `no-cm` saves ~89k by removing easymde/codemirror
 #   (the fancy markdown editor)
 #
-# `no-hl` saves ~41k by removing syntax hilighting in the text viewer
+# `no-hl` saves ~41k by removing syntax highlighting in the text viewer
 #
 # `no-fnt` saves ~9k by removing the source-code-pro font
 #   (browsers will try to use 'Consolas' instead)

--- a/scripts/tl.js
+++ b/scripts/tl.js
@@ -414,7 +414,7 @@ var tl_browser = {
 		"mm_enet": "Your internet connection is wonky",
 		"mm_edec": "This file is supposedly corrupted??",
 		"mm_esupp": "Your browser does not understand this audio format",
-		"mm_eunk": "Unknown Errol",
+		"mm_eunk": "Unknown Error",
 		"mm_e404": "Could not play audio; error 404: File not found.",
 		"mm_e403": "Could not play audio; error 403: Access denied.\n\nTry pressing F5 to reload, maybe you got logged out",
 		"mm_e500": "Could not play audio; error 500: Check server logs.",

--- a/srv/extend.md
+++ b/srv/extend.md
@@ -30,7 +30,7 @@ finally ./except/these/ones.md
 
 
 ### also-this.md
-whic hshoud be ./except/also-this.md
+which should be ./except/also-this.md
 
 
 
@@ -62,7 +62,7 @@ the difference is that with `copyparty_pre` you'll probably break various copypa
 
 
 # heres the plugins
-if there is anything below ths line in the preview then the plugin feature is disabled (good)
+if there is anything below this line in the preview then the plugin feature is disabled (good)
 
 
 


### PR DESCRIPTION
Found via `codespell -q 3 -L ascript,caf,clen,fo,nd,oen,pres,som,te,tread,warks -S "*.patch"`  
This PR complies with the DCO; https://developercertificate.org/