### PR TITLE
nix: add /etc/group to systemd sandbox

### DIFF
--- a/contrib/nixos/modules/copyparty.nix
+++ b/contrib/nixos/modules/copyparty.nix
@@ -279,6 +279,7 @@ in {
             "/nix/store"
             "-/etc/resolv.conf"
             "-/etc/nsswitch.conf"
+            "-/etc/group"
             "-/etc/hosts"
             "-/etc/localtime"
           ]


### PR DESCRIPTION
allows specifying groups by name in the unix socket

This PR complies with the DCO; https://developercertificate.org/  
