### PR TITLE
Disable the "use the real password" button on the connect page when there's no accounts

### DIFF
--- a/copyparty/web/svcs.html
+++ b/copyparty/web/svcs.html
@@ -36,7 +36,7 @@
             <span class="os lin mac">
                 {% if accs %}<code><b id="pw0">{{ pw }}</b></code>=password, {% endif %}<code><b>mp</b></code>=mountpoint
             </span>
-            <a href="#" id="setpw">use real password</a>
+            {% if accs %}<a href="#" id="setpw">use real password</a>{% endif %}
         </p>
 
 

--- a/copyparty/web/svcs.js
+++ b/copyparty/web/svcs.js
@@ -49,21 +49,21 @@ function setos(os) {
 setos(WINDOWS ? 'win' : LINUX ? 'lin' : MACOS ? 'mac' : 'idk');
 
 
-pwbutton = ebi('setpw')
-if (pwbutton != null)
-    pwbutton.onclick = function (e) {
-        ev(e);
-        modal.prompt('password:', '', function (v) {
-            if (!v)
-                return;
+function setpw() {
+    ev(e);
+    modal.prompt('password:', '', function (v) {
+        if (!v)
+            return;
 
-            var pw0 = ebi('pw0').innerHTML,
-                oa = QSA('b');
-        
-            for (var a = 0; a < oa.length; a++)
-                if (oa[a].innerHTML == pw0)
-                    oa[a].textContent = v;
+        var pw0 = ebi('pw0').innerHTML,
+            oa = QSA('b');
+    
+        for (var a = 0; a < oa.length; a++)
+            if (oa[a].innerHTML == pw0)
+                oa[a].textContent = v;
 
-            add_dls();
-        });
-    }
+        add_dls();
+    });
+}
+if (ebi('setpw'))
+    ebi('setpw').onclick = setpw;

--- a/copyparty/web/svcs.js
+++ b/copyparty/web/svcs.js
@@ -49,19 +49,21 @@ function setos(os) {
 setos(WINDOWS ? 'win' : LINUX ? 'lin' : MACOS ? 'mac' : 'idk');
 
 
-ebi('setpw').onclick = function (e) {
-    ev(e);
-    modal.prompt('password:', '', function (v) {
-        if (!v)
-            return;
+pwbutton = ebi('setpw')
+if (pwbutton != null)
+    pwbutton.onclick = function (e) {
+        ev(e);
+        modal.prompt('password:', '', function (v) {
+            if (!v)
+                return;
 
-        var pw0 = ebi('pw0').innerHTML,
-            oa = QSA('b');
+            var pw0 = ebi('pw0').innerHTML,
+                oa = QSA('b');
         
-        for (var a = 0; a < oa.length; a++)
-            if (oa[a].innerHTML == pw0)
-                oa[a].textContent = v;
+            for (var a = 0; a < oa.length; a++)
+                if (oa[a].innerHTML == pw0)
+                    oa[a].textContent = v;
 
-        add_dls();
-    });
-}
+            add_dls();
+        });
+    }


### PR DESCRIPTION
If you go to the connect page on a copyparty instance that has no accounts, the button to use a real password still shows up, while placeholder it changes doesn't.

Using it then just makes the UI explode so the button shouldn't show up


This PR complies with the DCO; https://developercertificate.org/  