### PR TITLE
cbz thumbnails: sort alphabetically

### DIFF
--- a/copyparty/mtag.py
+++ b/copyparty/mtag.py
@@ -166,12 +166,13 @@ def au_unpk(
             znil = [x for x in znil if "cover" in x[0]] or znil
             znil = [x for x in znil if CBZ_01.search(x[0])] or znil
             t = "cbz: %d files, %d hits" % (nf, len(znil))
+            using = sorted(znil)[0][1].filename
             if znil:
-                t += ", using " + znil[0][1].filename
+                t += ", using " + using
             log(t)
             if not znil:
                 raise Exception("no images inside cbz")
-            fi = zf.open(znil[0][1])
+            fi = zf.open(using)
 
         else:
             raise Exception("unknown compression %s" % (pk,))


### PR DESCRIPTION
Comic readers will sort alphabetically, but that isn't always the order in which the files are stored in the zip, so sort it before picking a thumbnail.

This PR complies with the DCO; https://developercertificate.org/  
