### PR TITLE
fix: copyparty server-side template Injection through eval 

### DIFF
--- a/copyparty/web/util.js
+++ b/copyparty/web/util.js
@@ -2001,9 +2001,9 @@ function load_md_plug(md_text, plug_type, defer) {
 
     var old_plug = md_plug[plug_type];
     if (!old_plug || old_plug[1] != js) {
-        js = 'const loc = new URL("' + location.href + '"), x = { ' + js + ' }; x;';
+        // Use Function constructor to avoid code injection via location.href
         try {
-            var x = eval(js);
+            var x = (new Function('loc', 'return { ' + js + ' };'))(new URL(location.href));
             if (x['ctor']) {
                 x['ctor']();
                 delete x['ctor'];


### PR DESCRIPTION
https://github.com/9001/copyparty/blob/4915b14be191bca9a91f942073650fee27b3231b/copyparty/web/util.js#L2004-L2004

https://github.com/9001/copyparty/blob/4915b14be191bca9a91f942073650fee27b3231b/copyparty/web/util.js#L2006-L2006


Directly evaluating user input (an HTTP request parameter) as code without properly sanitizing the input first allows an attacker arbitrary code execution. This can occur when user input is treated as JavaScript, or passed to a framework which interprets it as an expression to be evaluated. Examples include AngularJS expressions or JQuery selectors.


fix this vulnerability, we must ensure that user-controllable data (in this case, `location.href`) is not injected into code that is then evaluated with `eval`. The best way to do this is to avoid using `eval` entirely, especially with dynamically constructed code. If the intent is to provide the current URL as a variable to the evaluated code, we should instead use a safer alternative, such as the `Function` constructor with controlled arguments, or better yet, avoid dynamic code execution altogether.

In this specific case, we can use the `Function` constructor to create a function that takes `loc` as an argument, and then execute the user-provided code in a controlled scope. This way, we can pass the URL as a parameter, rather than interpolating it into the code string. This prevents injection via `location.href`. The code block (`js`) should also be validated or restricted to prevent further injection risks.

**Changes to make:**
- Replace the use of `eval` with the `Function` constructor, passing `loc` as an argument.
- Remove the interpolation of `location.href` into the code string.
- Ensure that the code block (`js`) is not otherwise tainted by user input, or document that it is trusted if that is the case.

**Files/regions to change:**
- In `copyparty/web/util.js`, lines 2004–2006.

**Methods/imports/definitions needed:**
- No new imports are needed.
- The code should define a function using the `Function` constructor, passing `loc` as an argument.
