### PR TITLE
Add `uv tool run copyparty` to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ just run **[copyparty-sfx.py](https://github.com/9001/copyparty/releases/latest/
 * or install [on arch](#arch-package) ╱ [on NixOS](#nixos-module) ╱ [through nix](#nix-package)
 * or if you are on android, [install copyparty in termux](#install-on-android)
 * or maybe you have a [synology nas / dsm](./docs/synology-dsm.md)
-* or if you have [uv](https://docs.astral.sh/uv/) installed, run `uvx copyparty`
+* or if you have [uv](https://docs.astral.sh/uv/) installed, run `uv tool run copyparty`
 * or if your computer is messed up and nothing else works, [try the pyz](#zipapp)
 * or if your OS is dead, give the [bootable flashdrive / cd-rom](https://a.ocv.me/pub/stuff/edcd001/enterprise-edition/) a spin
 * or if you don't trust copyparty yet and want to isolate it a little, then...

--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ just run **[copyparty-sfx.py](https://github.com/9001/copyparty/releases/latest/
 * or install [on arch](#arch-package) ╱ [on NixOS](#nixos-module) ╱ [through nix](#nix-package)
 * or if you are on android, [install copyparty in termux](#install-on-android)
 * or maybe you have a [synology nas / dsm](./docs/synology-dsm.md)
+* or if you have [uv](https://docs.astral.sh/uv/) installed, run `uvx copyparty`
 * or if your computer is messed up and nothing else works, [try the pyz](#zipapp)
 * or if your OS is dead, give the [bootable flashdrive / cd-rom](https://a.ocv.me/pub/stuff/edcd001/enterprise-edition/) a spin
 * or if you don't trust copyparty yet and want to isolate it a little, then...


### PR DESCRIPTION
I've confirmed that this command seems to work on both mac and linux.

To show that your contribution is compatible with the MIT License, please include the following text somewhere in this PR description:  
This PR complies with the DCO; https://developercertificate.org/  

We could go with `uvx copyparty` or `uv tool run copyparty` as they are [aliases of each other](https://docs.astral.sh/uv/guides/tools/). I'd favor `uv tool run` for clarity, but it's no big difference.
