### PR TITLE
nix: make usage in non-flake setups easier

### DIFF
--- a/README.md
+++ b/README.md
@@ -2344,7 +2344,7 @@ some recommended dependencies are enabled by default; [override the package](htt
 
 ## nixos module
 
-for this setup, you will need a [flake-enabled](https://nixos.wiki/wiki/Flakes) installation of NixOS.
+for [flake-enabled](https://nixos.wiki/wiki/Flakes) installations of NixOS:
 
 ```nix
 {
@@ -2368,6 +2368,33 @@ for this setup, you will need a [flake-enabled](https://nixos.wiki/wiki/Flakes) 
       ];
     };
   };
+}
+```
+
+if you don't use a flake in your configuration, you can use other dependency management tools like [npins](https://github.com/andir/npins), [niv](https://github.com/nmattia/niv), or even plain [`fetchTarball`](https://nix.dev/manual/nix/stable/language/builtins#builtins-fetchTarball), like so:
+
+```nix
+{ pkgs, ... }:
+
+let
+  # npins example, adjust for your setup. copyparty should be a path to the downloaded repo
+  # for niv, just replace the npins folder import with the sources.nix file
+  copyparty = (import ./npins).copyparty;
+
+  # or with fetchTarball:
+  copyparty = fetchTarball "https://github.com/9001/copyparty/archive/hovudstraum.tar.gz";
+in
+
+{
+  # load the copyparty NixOS module
+  imports = [ "${copyparty}/contrib/nixos/modules/copyparty.nix" ];
+
+  # add the copyparty overlay to expose the package to the module
+  nixpkgs.overlays = [ "${copyparty}/contrib/package/nix/overlay.nix" ];
+  # (optional) install the package globally
+  environment.systemPackages = [ pkgs.copyparty ];
+  # configure the copyparty module
+  services.copyparty.enable = true;
 }
 ```
 

--- a/contrib/package/nix/overlay.nix
+++ b/contrib/package/nix/overlay.nix
@@ -1,0 +1,11 @@
+final: prev: {
+  copyparty = final.python3.pkgs.callPackage ./copyparty {
+    ffmpeg = final.ffmpeg-full;
+  };
+
+  python3 = prev.python3.override {
+    packageOverrides = pyFinal: pyPrev: {
+      partftpy = pyFinal.callPackage ./partftpy { };
+    };
+  };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -12,16 +12,7 @@
     }:
     {
       nixosModules.default = ./contrib/nixos/modules/copyparty.nix;
-      overlays.default = final: prev: {
-        copyparty = final.python3.pkgs.callPackage ./contrib/package/nix/copyparty {
-          ffmpeg = final.ffmpeg-full;
-        };
-        python3 = prev.python3.override {
-          packageOverrides = pyFinal: pyPrev: {
-            partftpy = pyFinal.callPackage ./contrib/package/nix/partftpy { };
-          };
-        };
-      };
+      overlays.default = import ./contrib/package/nix/overlay.nix;
     }
     // flake-utils.lib.eachDefaultSystem (
       system:


### PR DESCRIPTION
using the nix expressions in setups where flakes aren't in use was possible, but a little unwieldy (you had to reconstruct the overlay defined in the flake to get copyparty in your nixpkgs set). this pr moves the overlay into it's own dedicated file, allowing it to be used directly without requiring something like [flake-compat](https://git.lix.systems/lix-project/flake-compat). there's also some extra documentation, illustrating how to use the module in a non-flake nixos setup.

~~i've also added a commit that removes a (seemingly) unnecessary evaluation of nixpkgs, to avoid contributing to the ["1000 instances of nixpkgs"](https://zimbatm.com/notes/1000-instances-of-nixpkgs) issue. this one might be a little controversial, so i've added it as a suggestion - if you're not interested in this change, i'll happily drop the commit. it's not super necessary for anything, just a potential optimisation i spotted.~~

this pr complies with the dco; https://developercertificate.org/  
