### PR TITLE
nix: proposed setup to hide `nixpkgs.overlays` from users

### DIFF
--- a/README.md
+++ b/README.md
@@ -2278,8 +2278,6 @@ for this setup, you will need a [flake-enabled](https://nixos.wiki/wiki/Flakes) 
         # load the copyparty NixOS module
         copyparty.nixosModules.default
         ({ pkgs, ... }: {
-          # add the copyparty overlay to expose the package to the module
-          nixpkgs.overlays = [ copyparty.overlays.default ];
           # (optional) install the package globally
           environment.systemPackages = [ pkgs.copyparty ];
           # configure the copyparty module

--- a/contrib/nixos/modules/copyparty.nix
+++ b/contrib/nixos/modules/copyparty.nix
@@ -1,3 +1,4 @@
+{ self }:
 {
   config,
   pkgs,
@@ -259,6 +260,9 @@ in
       command = "${getExe cfg.package} -c ${runtimeConfigPath}";
     in
     {
+      # add the copyparty overlay to expose the package to the module
+      nixpkgs.overlays = [ self.overlays.default ];
+
       systemd.services.copyparty = {
         description = "http file sharing hub";
         wantedBy = [ "multi-user.target" ];

--- a/flake.nix
+++ b/flake.nix
@@ -11,7 +11,7 @@
       flake-utils,
     }:
     {
-      nixosModules.default = ./contrib/nixos/modules/copyparty.nix;
+      nixosModules.default = import ./contrib/nixos/modules/copyparty.nix { inherit self; };
       overlays.default = final: prev: rec {
         copyparty = final.python3.pkgs.callPackage ./contrib/package/nix/copyparty {
           ffmpeg = final.ffmpeg-full;


### PR DESCRIPTION
This may conflicts with the PR https://github.com/9001/copyparty/pull/296 (for non-flake setup)

I will do a force push for this PR to make it also compatible for non-flake setup after that PR merge

This PR complies with the DCO; https://developercertificate.org/  
