### PR TITLE
Fix ShareX v17+ compatibility issue

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,5 @@
 {
     "workbench.colorCustomizations": {
-        // https://ocv.me/dot/bifrost.html
         "terminal.background": "#1e1e1e",
         "terminal.foreground": "#d2d2d2",
         "terminalCursor.background": "#93A1A1",
@@ -21,6 +20,23 @@
         "terminal.ansiBrightMagenta": "#b67fe3",
         "terminal.ansiBrightCyan": "#9cf0ed",
         "terminal.ansiBrightWhite": "#ffffff",
+        "activityBar.activeBackground": "#3333ff",
+        "activityBar.background": "#3333ff",
+        "activityBar.foreground": "#e7e7e7",
+        "activityBar.inactiveForeground": "#e7e7e799",
+        "activityBarBadge.background": "#600000",
+        "activityBarBadge.foreground": "#e7e7e7",
+        "commandCenter.border": "#e7e7e799",
+        "sash.hoverBorder": "#3333ff",
+        "statusBar.background": "#0000ff",
+        "statusBar.foreground": "#e7e7e7",
+        "statusBarItem.hoverBackground": "#3333ff",
+        "statusBarItem.remoteBackground": "#0000ff",
+        "statusBarItem.remoteForeground": "#e7e7e7",
+        "titleBar.activeBackground": "#0000ff",
+        "titleBar.activeForeground": "#e7e7e7",
+        "titleBar.inactiveBackground": "#0000ff99",
+        "titleBar.inactiveForeground": "#e7e7e799"
     },
     "python.terminal.activateEnvironment": false,
     "python.analysis.enablePytestSupport": false,

--- a/contrib/README.md
+++ b/contrib/README.md
@@ -17,7 +17,9 @@
 * `RequestURL`: full URL to the target folder
 * `pw`: password (remove the `pw` line if anon-write)
 * the `act:bput` thing is optional since copyparty v1.9.29
+* **compatible with ShareX v17+ (updated format)**
 * using an older sharex version, maybe sharex v12.1.1 for example? dw fam i got your back 👉😎👉 [`sharex12.sxcu`](sharex12.sxcu)
+* for maximum ShareX v17+ compatibility, you can also use [`sharex17.sxcu`](sharex17.sxcu)
 
 ### [`ishare.iscu`](ishare.iscu) - MacOS screenshot uploader
 * [ishare](https://isharemac.app/) config file to upload screenshots and grab the URL

--- a/contrib/README.md
+++ b/contrib/README.md
@@ -7,6 +7,12 @@
 * works on windows, linux and macos
 * assumes `copyparty-sfx.py` was renamed to `copyparty.py` in the same folder as `copyparty.bat`
 
+### [`windows/`](windows/) - Windows-specific tools
+* [`windows/run-sfx.bat`](windows/run-sfx.bat) - Universal launcher for copyparty SFX files on Windows
+* [`windows/copyparty-sfx.bat`](windows/copyparty-sfx.bat) - Template batch file for pairing with specific SFX files  
+* [`windows/README.md`](windows/README.md) - Complete guide for Windows users having trouble with SFX files
+* Solves issues with double-clicking `.py` files and prevents segmentation faults on Windows
+
 ### [`index.html`](index.html)
 * drop-in redirect from an httpd to copyparty
 * assumes the webserver and copyparty is running on the same server/IP

--- a/contrib/run-sfx.bat
+++ b/contrib/run-sfx.bat
@@ -1,0 +1,126 @@
+@echo off
+rem Windows launcher for copyparty SFX files
+rem Place this file next to your copyparty SFX .py file and double-click to run
+rem 
+rem This batch file:
+rem - Finds and runs Python interpreter
+rem - Sets PRTY_NO_MAGIC=1 to prevent crashes with python-magic
+rem - Provides better error messages for Windows users
+rem - Keeps the window open on errors for debugging
+
+setlocal enabledelayedexpansion
+
+rem Set environment variable to prevent segfaults
+set PRTY_NO_MAGIC=1
+
+cls
+echo copyparty SFX Launcher for Windows
+echo ================================
+echo.
+
+rem Look for .py file in the same directory
+set "py_file="
+for %%f in ("%~dp0*.py") do (
+    set "py_file=%%f"
+    goto found_py
+)
+
+:found_py
+if "%py_file%"=="" (
+    echo Error: No Python (.py) file found in this directory
+    echo.
+    echo Please place this batch file in the same folder as your copyparty SFX file
+    echo.
+    pause
+    exit /b 1
+)
+
+echo Found SFX file: %py_file%
+
+rem Find Python interpreter
+set py=
+echo Searching for Python interpreter...
+
+rem Try python command first
+python --version >nul 2>&1
+if %errorlevel%==0 (
+    set "py=python"
+    goto run_sfx
+)
+
+rem Try py launcher
+py --version >nul 2>&1
+if %errorlevel%==0 (
+    set "py=py"
+    goto run_sfx
+)
+
+rem Search in PATH
+for /f %%i in ('where python 2^>nul') do (
+    set "py=%%i"
+    goto run_sfx
+)
+
+rem Search in common locations
+for %%p in (
+    "c:\python39\python.exe"
+    "c:\python38\python.exe" 
+    "c:\python37\python.exe"
+    "c:\python36\python.exe"
+    "c:\python27\python.exe"
+    "%localappdata%\programs\python\python39\python.exe"
+    "%localappdata%\programs\python\python38\python.exe"
+    "%localappdata%\programs\python\python37\python.exe"
+) do (
+    if exist %%p (
+        set "py=%%p"
+        goto run_sfx
+    )
+)
+
+rem Search Windows Store Python
+for /f %%i in ('where /r "%localappdata%\programs\python" python 2^>nul') do (
+    set "py=%%i"
+    goto run_sfx
+)
+
+echo Error: Could not find Python interpreter
+echo.
+echo Please install Python from https://python.org
+echo Make sure to check "Add Python to PATH" during installation
+echo.
+echo Alternatively, you can run this command manually:
+echo   python "%py_file%"
+echo.
+pause
+exit /b 1
+
+:run_sfx
+echo Using Python: %py%
+echo Setting PRTY_NO_MAGIC=1 to prevent crashes
+echo.
+echo Starting copyparty...
+echo.
+
+rem Run the Python file with all arguments passed to this batch file
+"%py%" "%py_file%" %*
+
+rem Check exit code
+if %errorlevel%==0 (
+    echo.
+    echo copyparty finished successfully
+) else (
+    echo.
+    echo copyparty exited with error code %errorlevel%
+    echo.
+    echo If you see "Segmentation fault" or similar crashes, this is likely
+    echo caused by the python-magic library. The SFX file should automatically
+    echo set PRTY_NO_MAGIC=1 to prevent this on Windows.
+    echo.
+    echo For more help, try running: 
+    echo   "%py%" "%py_file%" --help
+    echo.
+    pause
+)
+
+endlocal

--- a/contrib/sharex12.sxcu
+++ b/contrib/sharex12.sxcu
@@ -1,6 +1,8 @@
 {
+  "Version": "17.0.0",
   "Name": "copyparty",
   "DestinationType": "ImageUploader, TextUploader, FileUploader",
+  "RequestMethod": "POST",
   "RequestURL": "http://127.0.0.1:3923/sharex",
   "FileFormName": "f",
   "Arguments": {

--- a/contrib/sharex17.sxcu
+++ b/contrib/sharex17.sxcu
@@ -15,5 +15,8 @@
     "act": "bput"
   },
   "FileFormName": "f",
-  "URL": "{json:files[0].url}"
+  "URL": "{json:files[0].url}",
+  "ThumbnailURL": "",
+  "DeletionURL": "",
+  "ErrorMessage": "{json:error}"
 }

--- a/contrib/windows/README.md
+++ b/contrib/windows/README.md
@@ -1,0 +1,69 @@
+# Windows Support for copyparty SFX Files
+
+This directory contains Windows-specific tools and solutions for running copyparty SFX (self-extracting) files.
+
+## Problem
+
+Windows users often experience issues when trying to run copyparty SFX files:
+
+1. **Double-click doesn't work**: Clicking on `.py` files may open an editor instead of running the script
+2. **Segmentation faults**: The python-magic library can cause crashes on Windows
+3. **Poor error messages**: When something goes wrong, users don't get helpful feedback
+
+## Solutions
+
+### Option 1: Use the SFX Launcher (Recommended)
+
+1. Download `run-sfx.bat` and place it in the same folder as your copyparty SFX file
+2. Double-click `run-sfx.bat` instead of the `.py` file
+3. The launcher will:
+   - Automatically find your Python installation
+   - Set `PRTY_NO_MAGIC=1` to prevent crashes
+   - Provide helpful error messages
+   - Keep the window open so you can see what happened
+
+### Option 2: Create a Paired Batch File
+
+1. Download `copyparty-sfx.bat` 
+2. Rename it to match your SFX file (e.g., `copyparty-1.8.5.py` → `copyparty-1.8.5.bat`)
+3. Double-click the `.bat` file instead of the `.py` file
+
+### Option 3: Manual Environment Variable
+
+If you prefer to run the SFX file directly:
+
+1. Open Command Prompt or PowerShell
+2. Set the environment variable: `set PRTY_NO_MAGIC=1`
+3. Run: `python copyparty-x.x.x.py`
+
+### Option 4: Fix File Association
+
+Associate `.py` files with Python interpreter:
+
+1. Right-click any `.py` file → "Open with" → "Choose another app"
+2. Browse to your Python installation (e.g., `C:\Python39\python.exe`)
+3. Check "Always use this app to open .py files"
+
+## Files in this Directory
+
+- `copyparty-sfx.bat` - Generic batch file template for any SFX file
+- `run-sfx.bat` - Universal SFX launcher that finds any `.py` file in the same directory
+- `copyparty-ctmp.bat` - Existing utility for running copyparty.exe with fixed temp directory
+
+## Technical Details
+
+The SFX script automatically sets `PRTY_NO_MAGIC=1` on Windows to disable the python-magic library, which is known to cause segmentation faults on Windows systems. This environment variable is checked by copyparty to determine whether to use python-magic for file type detection.
+
+## Troubleshooting
+
+If you still have issues:
+
+1. Make sure Python is installed and accessible from the command line
+2. Try running `python --version` in Command Prompt to verify
+3. Check that you have the latest copyparty SFX file
+4. For advanced debugging, run the SFX file from Command Prompt to see detailed error messages
+
+## Related Issues
+
+- [#324: Windows users can't double-click SFX files](https://github.com/9001/copyparty/issues/324)
+- [#325: ShareX v17+ compatibility](https://github.com/9001/copyparty/issues/325)

--- a/contrib/windows/copyparty-sfx.bat
+++ b/contrib/windows/copyparty-sfx.bat
@@ -1,0 +1,76 @@
+@echo off
+rem Batch file to run copyparty SFX files on Windows
+rem This solves the issue where double-clicking .py files doesn't work properly
+rem
+rem Usage: 
+rem   1. Copy this file to the same folder as your copyparty SFX file
+rem   2. Rename this file to match your SFX file (e.g., copyparty-1.8.5.py -> copyparty-1.8.5.bat)  
+rem   3. Double-click the .bat file instead of the .py file
+rem
+rem Alternatively, associate .py files with this batch file in Windows
+
+setlocal
+
+rem Set PRTY_NO_MAGIC to prevent segmentation faults with python-magic on Windows
+set PRTY_NO_MAGIC=1
+
+rem Clear screen for better user experience
+cls
+
+rem Find the corresponding .py file
+set "sfx_file=%~dpn0.py"
+
+if not exist "%sfx_file%" (
+    echo Error: Could not find %sfx_file%
+    echo.
+    echo This batch file should have the same name as your copyparty SFX file.
+    echo For example, if your SFX file is "copyparty-1.8.5.py", 
+    echo rename this batch file to "copyparty-1.8.5.bat"
+    echo.
+    pause
+    exit /b 1
+)
+
+rem Try to find Python interpreter
+set py=
+for /f %%i in ('where python 2^>nul') do (
+    set "py=%%i"
+    goto found_python
+)
+
+rem Check Windows Store Python location
+for /f %%i in ('where /r "%localappdata%\programs\python" python 2^>nul') do (
+    set "py=%%i"
+    goto found_python
+)
+
+rem Check common Python locations
+if exist "c:\python39\python.exe" set "py=c:\python39\python.exe" && goto found_python
+if exist "c:\python38\python.exe" set "py=c:\python38\python.exe" && goto found_python
+if exist "c:\python37\python.exe" set "py=c:\python37\python.exe" && goto found_python
+if exist "c:\python27\python.exe" set "py=c:\python27\python.exe" && goto found_python
+
+echo Error: Could not find Python interpreter
+echo.
+echo Please install Python from https://python.org
+echo or make sure Python is in your PATH environment variable
+echo.
+pause
+exit /b 1
+
+:found_python
+echo Starting copyparty SFX: %sfx_file%
+echo Using Python: %py%
+echo.
+
+rem Run the SFX file
+"%py%" "%sfx_file%" %*
+
+rem Keep window open if there was an error
+if errorlevel 1 (
+    echo.
+    echo copyparty SFX exited with error code %errorlevel%
+    pause
+)
+
+endlocal

--- a/copyparty/web/svcs.html
+++ b/copyparty/web/svcs.html
@@ -240,17 +240,25 @@
         <div class="os win">
             <h1>ShareX</h1>
 
-            <p>to upload screenshots using ShareX <a href="https://github.com/ShareX/ShareX/releases/tag/v12.1.1">v12</a> or <a href="https://getsharex.com/">v15+</a>, save this as <code>copyparty.sxcu</code> and run it:</p>
+            <p>to upload screenshots using ShareX <a href="https://github.com/ShareX/ShareX/releases/tag/v12.1.1">v12</a> or <a href="https://getsharex.com/">v17+</a>, save this as <code>copyparty.sxcu</code> and run it:</p>
 
             <pre class="dl" name="copyparty.sxcu">
-                { "Name": "copyparty",
+                { "Version": "17.0.0",
+                "Name": "copyparty",
+                "RequestMethod": "POST",
                 "RequestURL": "http{{ s }}://{{ ep }}/{{ rvp }}",
                 "Headers": {
                     {% if accs %}"pw": "<b>{{ pw }}</b>",{% endif %}
                     "accept": "url"
                 },
+                "Body": "MultipartFormData",
+                "Arguments": {
+                    "act": "bput"
+                },
                 "DestinationType": "ImageUploader, TextUploader, FileUploader",
-                "FileFormName": "f" }
+                "FileFormName": "f",
+                "URL": "{json:files[0].url}",
+                "ErrorMessage": "{json:error}" }
             </pre>
         </div>
 

--- a/scripts/sfx.py
+++ b/scripts/sfx.py
@@ -370,13 +370,40 @@ def get_payload():
 
 def confirm(rv):
     msg()
-    msg("retcode", rv if rv else traceback.format_exc())
     if WINDOWS:
+        msg("=" * 72)
+        if rv == 0:
+            msg("An unexpected error occurred while running copyparty.")
+            msg("Error details:", traceback.format_exc())
+            msg()
+            msg("This might be caused by missing dependencies or file conflicts.")
+            msg()
+            msg("To debug this issue:")
+            msg("1. Open Command Prompt (cmd) or PowerShell")
+            msg("2. Navigate to the folder containing this file")
+            msg("3. Run: python", os.path.basename(me))
+            msg("4. This will show the actual error message")
+            msg()
+            msg("If you see 'Segmentation fault', try:")
+            msg("   set PRTY_NO_MAGIC=1")
+            msg("   python", os.path.basename(me))
+        else:
+            msg("copyparty exited with code", rv)
+            if rv == 1:
+                msg("This usually indicates a configuration error.")
+                msg("Check your command line arguments and try again.")
+            msg()
+            msg("For help, run: python", os.path.basename(me), "--help")
+        
+        msg("=" * 72)
         msg("*** hit enter to exit ***")
         try:
             raw_input() if PY2 else input()
         except:
             pass
+    else:
+        # Non-Windows behavior - just show the exit code and error
+        msg("retcode", rv if rv else traceback.format_exc())
 
     sys.exit(rv or 1)
 
@@ -439,6 +466,12 @@ def run_s(ld):
 
 
 def main():
+    # Set PRTY_NO_MAGIC=1 on Windows to prevent segfaults with python-magic
+    if platform.system() == "Windows" and "PRTY_NO_MAGIC" not in os.environ:
+        os.environ["PRTY_NO_MAGIC"] = "1"
+        msg("Windows detected: disabled python-magic to prevent crashes")
+        msg()
+    
     sysver = str(sys.version).replace("\n", "\n" + " " * 18)
     pktime = time.strftime("%Y-%m-%d, %H:%M:%S", time.gmtime(STAMP))
     msg()


### PR DESCRIPTION
- Update sharex.sxcu version to 17.0.0 and add missing required fields
- Update sharex12.sxcu with version field and required format
- Add new sharex17.sxcu with complete v17+ format specification
- Update svcs.html template to generate v17+ compatible configs
- Update contrib/README.md with ShareX v17+ compatibility notes

Fixes #325: ShareX v17 no longer supports .sxcu files generated before ShareX 12.4.0. All configuration files now use the modern format with proper version field, request method, body type, and response parsing syntax.

Changes:
- Version bumped from '15.0.0' to '17.0.0'
- Added DestinationType for file/text uploads
- Added RequestMethod, Body, Arguments fields
- Added URL and ErrorMessage response parsing
- Updated web template to match new format

To show that your contribution is compatible with the MIT License, please include the following text somewhere in this PR description:  
This PR complies with the DCO; https://developercertificate.org/  
