### PR TITLE
Documented missing search endpoint along with a new 'curl' example

### DIFF
--- a/README.md
+++ b/README.md
@@ -2451,6 +2451,8 @@ interact with copyparty using non-browser clients
     `post movie.mkv`
   * `chunk(){ curl -H pw:wark -T- http://127.0.0.1:3923/;}`  
     `chunk <movie.mkv`
+  *  `search() { curl -H "Content-Type: application/json" -X POST --data '{"n":42,"q":"'"${1}"'"}' http://127.0.0.1:3923?srch; }`
+    `search 'name like *.jpg*'`
 
 * bash: when curl and wget is not available or too boring
   * `(printf 'PUT /junk?pw=wark HTTP/1.1\r\n\r\n'; cat movie.mkv) | nc 127.0.0.1 3923`

--- a/docs/devnotes.md
+++ b/docs/devnotes.md
@@ -198,9 +198,9 @@ authenticate using header `Cookie: cppwd=foo` or url param `&pw=foo`
 | GET | `?th=opus` | convert audio file to 128kbps opus |
 | GET | `?th=caf` | ...in the iOS-proprietary container |
 
-| method | body | result |
-|--|--|--|
-| jPOST | `{"q":"foo"}` | do a server-wide search; see the `[🔎]` search tab `raw` field for syntax |
+| method | params | body | result |
+|--|--|--|--|
+| jPOST | `?srch` | `{"n":42,"q":"foo"}` | do a server-wide search; see the `[🔎]` search tab `raw` field for syntax |
 
 | method | params | body | result |
 |--|--|--|--|


### PR DESCRIPTION
I'm using `copyparty` to finally untangle my multiple attempts at media consolidation and backups, and it's been going excellently so far.

I'm now at the phase where I wanted to put things into different buckets and set out to use the search api, but found a couple things missing from the documentation.

As a thanks for this wonderful application, I added some snippets of text to hopefully help others if/when they choose to go down this route.


This PR complies with the DCO; https://developercertificate.org/  
