### PR TITLE
Nix: remove space from list separator

### DIFF
--- a/contrib/nixos/modules/copyparty.nix
+++ b/contrib/nixos/modules/copyparty.nix
@@ -22,7 +22,7 @@ let
   mkValueString =
     value:
     if isList value then
-      (concatStringsSep ", " (map mkValueString value))
+      (concatStringsSep "," (map mkValueString value))
     else if isAttrs value then
       "\n" + (mkAttrsString value)
     else


### PR DESCRIPTION
The extra spaces made copyparty freak out if you tried listening to an ip address and a unix socket at the same time.

This PR complies with the DCO; https://developercertificate.org/  
