### PR TITLE
add Debian packaging via MPR

### DIFF
--- a/contrib/package/makedeb-mpr/PKGBUILD
+++ b/contrib/package/makedeb-mpr/PKGBUILD
@@ -1,0 +1,46 @@
+# Maintainer: Morgan Adamiec <morganamilo@archlinux.org>
+# Contributor: icxes <dev.null@need.moe>
+# makedeb PKGBUILD script writer: Beethoven <beethovenisadog@protonmail.com>
+
+
+pkgname=copyparty
+pkgver=1.18.8
+pkgrel=1
+pkgdesc="File server with accelerated resumable uploads, dedup, WebDAV, FTP, TFTP, zeroconf, media indexer, thumbnails++"
+arch=("any")
+url="https://github.com/9001/${pkgname}"
+license=('MIT')
+depends=("bash" "python3" "lsof" "python3-jinja2")
+makedepends=("python3-wheel" "python3-setuptools" "python3-build" "python3-installer" "make" "pigz")
+optdepends=("ffmpeg: thumbnails for videos, images (slower) and audio, music tags"
+            "golang-cfssl: generate TLS certificates on startup"
+            "python3-mutagen: music tags (alternative)"
+            "python3-pil: thumbnails for images"
+            "python3-openssl: ftps functionality"
+            "python3-zmq: send zeromq messages from event-hooks"
+            "python3-argon2: hashed passwords in config"
+)
+source=("https://github.com/9001/${pkgname}/releases/download/v${pkgver}/${pkgname}-${pkgver}.tar.gz")
+backup=("/etc/${pkgname}.d/init" )
+sha256sums=("5bbda1e67f20a4a7fc10887235dba441544642d33c6d918f8a46867cda684572")
+
+build() {
+    cd "${srcdir}/${pkgname}-${pkgver}/copyparty/web"
+    make
+
+    cd "${srcdir}/${pkgname}-${pkgver}"
+    python -m build --wheel --no-isolation
+}
+
+package() {
+    cd "${srcdir}/${pkgname}-${pkgver}"
+    python -m installer --destdir="$pkgdir" dist/*.whl
+
+    install -dm755 "${pkgdir}/etc/${pkgname}.d"
+    install -Dm755 "bin/prisonparty.sh" "${pkgdir}/usr/bin/prisonparty"
+    install -Dm644 "contrib/package/makedeb-mpr/${pkgname}.conf" "${pkgdir}/etc/${pkgname}.d/init"
+    install -Dm644 "contrib/package/makedeb-mpr/${pkgname}.service" "${pkgdir}/usr/lib/systemd/system/${pkgname}.service"
+    install -Dm644 "contrib/package/makedeb-mpr/prisonparty.service" "${pkgdir}/usr/lib/systemd/system/prisonparty.service"
+    install -Dm644 "contrib/package/makedeb-mpr/index.md" "${pkgdir}/var/lib/${pkgname}-jail/README.md"
+    install -Dm644 "LICENSE" "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE"
+}

--- a/contrib/package/makedeb-mpr/PKGBUILD
+++ b/contrib/package/makedeb-mpr/PKGBUILD
@@ -1,6 +1,4 @@
-# Maintainer: Morgan Adamiec <morganamilo@archlinux.org>
-# Contributor: icxes <dev.null@need.moe>
-# makedeb PKGBUILD script writer: Beethoven <beethovenisadog@protonmail.com>
+# Contributor: Beethoven <beethovenisadog@protonmail.com>
 
 
 pkgname=copyparty

--- a/contrib/package/makedeb-mpr/copyparty.conf
+++ b/contrib/package/makedeb-mpr/copyparty.conf
@@ -1,0 +1,7 @@
+## import all *.conf files from the current folder (/etc/copyparty.d)
+% ./
+
+# add additional .conf files to this folder;
+# see example config files for reference:
+# https://github.com/9001/copyparty/blob/hovudstraum/docs/example.conf
+# https://github.com/9001/copyparty/tree/hovudstraum/docs/copyparty.d

--- a/contrib/package/makedeb-mpr/copyparty.service
+++ b/contrib/package/makedeb-mpr/copyparty.service
@@ -1,0 +1,32 @@
+# this will start `/usr/bin/copyparty-sfx.py`
+# and read config from `/etc/copyparty.d/*.conf`
+#
+# you probably want to:
+#   change "User=cpp" and "/home/cpp/" to another user
+#
+# unless you add -q to disable logging, you may want to remove the
+#   following line to allow buffering (slightly better performance):
+#   Environment=PYTHONUNBUFFERED=x
+
+[Unit]
+Description=copyparty file server
+
+[Service]
+Type=notify
+SyslogIdentifier=copyparty
+Environment=PYTHONUNBUFFERED=x
+WorkingDirectory=/var/lib/copyparty-jail
+ExecReload=/bin/kill -s USR1 $MAINPID
+
+# user to run as + where the TLS certificate is (if any)
+User=cpp
+Environment=XDG_CONFIG_HOME=/home/cpp/.config
+
+# stop systemd-tmpfiles-clean.timer from deleting copyparty while it's running
+ExecStartPre=+/bin/bash -c 'mkdir -p /run/tmpfiles.d/ && echo "x /tmp/pe-copyparty*" > /run/tmpfiles.d/copyparty.conf'
+
+# run copyparty
+ExecStart=/usr/bin/python3 /usr/bin/copyparty -c /etc/copyparty.d/init
+
+[Install]
+WantedBy=multi-user.target

--- a/contrib/package/makedeb-mpr/index.md
+++ b/contrib/package/makedeb-mpr/index.md
@@ -1,0 +1,3 @@
+this is `/var/lib/copyparty-jail`, the fallback webroot when copyparty has not yet been configured
+
+please add some `*.conf` files to `/etc/copyparty.d/`

--- a/contrib/package/makedeb-mpr/prisonparty.service
+++ b/contrib/package/makedeb-mpr/prisonparty.service
@@ -1,0 +1,33 @@
+# this will start `/usr/bin/copyparty-sfx.py`
+# in a chroot, preventing accidental access elsewhere,
+# and read copyparty config from `/etc/copyparty.d/*.conf`
+#
+# expose additional filesystem locations to copyparty
+#   by listing them between the last `cpp` and `--`
+#
+# `cpp cpp` = user/group to run copyparty as; can be IDs (1000 1000)
+#
+# unless you add -q to disable logging, you may want to remove the
+#   following line to allow buffering (slightly better performance):
+#   Environment=PYTHONUNBUFFERED=x
+
+[Unit]
+Description=copyparty file server
+
+[Service]
+SyslogIdentifier=prisonparty
+Environment=PYTHONUNBUFFERED=x
+WorkingDirectory=/var/lib/copyparty-jail
+ExecReload=/bin/kill -s USR1 $MAINPID
+
+# stop systemd-tmpfiles-clean.timer from deleting copyparty while it's running
+ExecStartPre=+/bin/bash -c 'mkdir -p /run/tmpfiles.d/ && echo "x /tmp/pe-copyparty*" > /run/tmpfiles.d/copyparty.conf'
+
+# run copyparty
+ExecStart=/bin/bash /usr/bin/prisonparty /var/lib/copyparty-jail cpp cpp \
+  /etc/copyparty.d \
+  -- \
+  /usr/bin/python3 /usr/bin/copyparty -c /etc/copyparty.d/init
+
+[Install]
+WantedBy=multi-user.target

--- a/scripts/prep.sh
+++ b/scripts/prep.sh
@@ -22,10 +22,31 @@ update_arch_pkgbuild() {
     rm -rf x
 }
 
+update_mpr_pkgbuild() {
+    cd "$self/../contrib/package/makedeb-mpr"
+    rm -rf x
+    mkdir x
+
+    sha=$(sha256sum "$self/../dist/copyparty-$ver.tar.gz" | awk '{print$1}')
+
+    # awk -v ver=$ver -v sha=$sha '
+    #     /^pkgver=/{sub(/[0-9\.]+/,ver)};
+    #     /^sha256sums=/{sub(/[0-9a-f]{64}/,sha)};
+    #     1' PKGBUILD >a
+    # mv a PKGBUILD
+
+		echo thing 1
+		sed -s -i "s/pkgver=\"\"/pkgver=\"$ver\"/" PKGBUILD
+		sed -s -i "s/sha256sums=(\".*\")/sha256sums=(\"$sha\")/" PKGBUILD
+
+    rm -rf x
+}
+
 update_nixos_pin() {
     ( cd $self/../contrib/package/nix/copyparty;
       ./update.py $self/../dist/copyparty-sfx.py )
 }
 
 update_arch_pkgbuild
+update_mpr_pkgbuild
 update_nixos_pin


### PR DESCRIPTION
this took most of my day but i'm happy with the result.
you should even be able to distribute the resulting package on debian-based distros.

the MPR is a debian equivalent to the arch AUR. instead of making arch packages, it makes debian .deb packages.
there's even a repository for them! https://mpr.makedeb.org/

there are two optdepends that don't have equivalents as of debian 12, those being `python-pyvips` and `libkeyfinder`. you'll miss out on higher quality thumbnails and musical key detection, but those packages just aren't available.

installation is simple:
* install makedeb `bash -ci "$(wget -qO - 'https://shlink.makedeb.org/install')"`
* clone the repo, copy `contrib/package/makedeb-mpr/PKGBUILD` somewhere (or get the raw)
* `makedeb -s` to build the package
* `sudo apt install ./copyparty_$version_$architecture.deb` to install
* `sudo apt purge copyparty` to uninstall

this PR complies with the DCO; https://developercertificate.org/  
