### PR TITLE
[u2c.py] Fix unicode files argument handling for Python 2.7

### DIFF
--- a/bin/u2c.py
+++ b/bin/u2c.py
@@ -52,6 +52,7 @@ if PY2:
 
     sys.dont_write_bytecode = True
     bytes = str
+    files_decoder = lambda s: unicode(s, 'utf8')
 else:
     from urllib.parse import quote_from_bytes as quote
     from urllib.parse import unquote_to_bytes as unquote
@@ -61,6 +62,7 @@ else:
     from queue import Queue
 
     unicode = str
+    files_decoder = unicode
 
 
 WTF8 = "replace" if PY2 else "surrogateescape"
@@ -1532,7 +1534,7 @@ source file/folder selection uses rsync syntax, meaning that:
 """)
 
     ap.add_argument("url", type=unicode, help="server url, including destination folder")
-    ap.add_argument("files", type=unicode, nargs="+", help="files and/or folders to process")
+    ap.add_argument("files", type=files_decoder, nargs="+", help="files and/or folders to process")
     ap.add_argument("-v", action="store_true", help="verbose")
     ap.add_argument("-a", metavar="PASSWD", help="password or $filepath")
     ap.add_argument("-s", action="store_true", help="file-search (disables upload)")


### PR DESCRIPTION
As mentioned in https://stackoverflow.com/questions/22947181/dont-argparse-read-unicode-from-commandline it is a known issue with Python 2.7 and `argparse` because Python 2.7 treats `sys.argv` as a list of byte strings, not Unicode strings, while Python 3 does. So when passing in `files` which contains unicode (Chinese, Japanese...) results in the following error:
```
$ ~/u2c.py -a wark copyparty.domain.name/movies/ 飞黄腾达.mp4 
/share/homes/xu/u2c.py:1520: UnicodeWarning: Unicode equal comparison failed to convert both arguments to Unicode - interpreting them as being unequal
  if "--version" in sys.argv:
/share/homes/xu/u2c.py:1524: UnicodeWarning: Unicode unequal comparison failed to convert both arguments to Unicode - interpreting them as being unequal
  sys.argv = [x for x in sys.argv if x != "--ws"]
usage: u2c.py [-h] [-v] [-a PASSWD] [-s] [-x REGEX] [--ok] [--touch] [--ow]
               [--owo] [--spd] [--version] [-u] [-ud] [-uf PATH] [--cls]
               [--rh TRIES] [--dl] [--dr] [--drd] [--wsalt S] [--chs] [--jw]
               [-j CONNS] [-J CORES] [--sz MiB] [--szm MiB] [-nh] [-ns]
               [--cxp SEC] [--cd SEC] [--safe] [-z] [-te PATH] [-td]
               url files [files ...]
u2c.py: error: argument files: invalid unicode value: '\xe9\xa3\x9e\xe9\xbb\x84\xe8\x85\xbe\xe8\xbe\xbe.mp4'
```
This PR fixes this by explicitly specifying encoding when handling `files` arg. It's only effective for Python 2, no behavior change is expected for Python 3.

Note that this issue might happen to other arguments using `type=unicode` (e.g. `url`) but I suppose fixing `files` arg should be the most useful case. I haven't tested for other args yet.

This PR complies with the DCO; https://developercertificate.org/  
