### PR TITLE
add PRTY_CONFIG environment variable for loading the config file

### DIFF
--- a/copyparty/__main__.py
+++ b/copyparty/__main__.py
@@ -990,7 +990,7 @@ def build_flags_desc():
 
 def add_general(ap, nc, srvname):
     ap2 = ap.add_argument_group('general options')
-    ap2.add_argument("-c", metavar="PATH", type=u, action="append", help="add config file")
+    ap2.add_argument("-c", metavar="PATH", type=u, default=[os.environ.get("PRTY_CONFIG", ".")], action="append", help="add config file")
     ap2.add_argument("-nc", metavar="NUM", type=int, default=nc, help="max num clients")
     ap2.add_argument("-j", metavar="CORES", type=int, default=1, help="max num cpu cores, 0=all")
     ap2.add_argument("-a", metavar="ACCT", type=u, action="append", help="add account, \033[33mUSER\033[0m:\033[33mPASS\033[0m; example [\033[32med:wark\033[0m]")


### PR DESCRIPTION
To show that your contribution is compatible with the MIT License, please include the following text somewhere in this PR description:  
This PR complies with the DCO; https://developercertificate.org/  

not sure if this is the best or even a smart way of doing this but it is what it is