### PR TITLE
add the ability to transcode to wav and flac formats

### DIFF
--- a/copyparty/__main__.py
+++ b/copyparty/__main__.py
@@ -1449,6 +1449,8 @@ def add_transcoding(ap):
     ap2.add_argument("--q-mp3", metavar="QUALITY", type=u, default="q2", help="target quality for transcoding to mp3, for example [\033[32m192k\033[0m] (CBR) or [\033[32mq0\033[0m] (CQ/CRF, q0=maxquality, q9=smallest); set 0 to disable")
     ap2.add_argument("--no-caf", action="store_true", help="disable transcoding to caf-opus (affects iOS v12~v17), will use mp3 instead")
     ap2.add_argument("--no-owa", action="store_true", help="disable transcoding to webm-opus (iOS v18 and later), will use mp3 instead")
+    ap2.add_argument("--no-wav", action="store_true", help="disable transcoding to wav (lossless, uncompressed)")
+    ap2.add_argument("--no-flac", action="store_true", help="disable transcoding to flac (lossless, compressed)")
     ap2.add_argument("--no-acode", action="store_true", help="disable audio transcoding")
     ap2.add_argument("--no-bacode", action="store_true", help="disable batch audio transcoding by folder download (zip/tar)")
     ap2.add_argument("--ac-maxage", metavar="SEC", type=int, default=86400, help="delete cached transcode output after \033[33mSEC\033[0m seconds")

--- a/copyparty/httpcli.py
+++ b/copyparty/httpcli.py
@@ -4684,7 +4684,7 @@ class HttpCli(object):
         # for f in fgen: print(repr({k: f[k] for k in ["vp", "ap"]}))
         cfmt = ""
         if self.thumbcli and not self.args.no_bacode:
-            for zs in ("opus", "mp3", "w", "j", "p"):
+            for zs in ("opus", "mp3", "wav", "w", "j", "p"):
                 if zs in self.ouparam or uarg == zs:
                     cfmt = zs
 

--- a/copyparty/httpcli.py
+++ b/copyparty/httpcli.py
@@ -4684,7 +4684,7 @@ class HttpCli(object):
         # for f in fgen: print(repr({k: f[k] for k in ["vp", "ap"]}))
         cfmt = ""
         if self.thumbcli and not self.args.no_bacode:
-            for zs in ("opus", "mp3", "wav", "w", "j", "p"):
+            for zs in ("opus", "mp3", "flac", "wav", "w", "j", "p"):
                 if zs in self.ouparam or uarg == zs:
                     cfmt = zs
 

--- a/copyparty/mtag.py
+++ b/copyparty/mtag.py
@@ -270,6 +270,8 @@ def parse_ffprobe(txt: str) -> tuple[dict[str, tuple[int, Any]], dict[str, list[
                 ["channel_layout", "chs"],
                 ["sample_rate", ".hz"],
                 ["bit_rate", ".aq"],
+                ["bits_per_sample", ".bps"],
+                ["bits_per_raw_sample", ".bprs"],
                 ["duration", ".dur"],
             ]
 

--- a/copyparty/th_cli.py
+++ b/copyparty/th_cli.py
@@ -88,7 +88,7 @@ class ThumbCli(object):
         if rem.startswith(".hist/th/") and rem.split(".")[-1] in ["webp", "jpg", "png"]:
             return os.path.join(ptop, rem)
 
-        if fmt[:1] in "jw":
+        if fmt[:1] in "jw" and fmt != "wav":
             sfmt = fmt[:1]
 
             if sfmt == "j" and self.args.th_no_jpg:
@@ -129,7 +129,7 @@ class ThumbCli(object):
 
         tpath = thumb_path(histpath, rem, mtime, fmt, self.fmt_ffa)
         tpaths = [tpath]
-        if fmt[:1] == "w":
+        if fmt[:1] == "w" and fmt != "wav":
             # also check for jpg (maybe webp is unavailable)
             tpaths.append(tpath.rsplit(".", 1)[0] + ".jpg")
 

--- a/copyparty/th_srv.py
+++ b/copyparty/th_srv.py
@@ -50,7 +50,7 @@ HAVE_AVIF = False
 HAVE_WEBP = False
 
 EXTS_TH = set(["jpg", "webp", "png"])
-EXTS_AC = set(["opus", "owa", "caf", "mp3"])
+EXTS_AC = set(["opus", "owa", "caf", "mp3", "wav"])
 EXTS_SPEC_SAFE = set("aif aiff flac mp3 opus wav".split())
 
 PTN_TS = re.compile("^-?[0-9a-f]{8,10}$")
@@ -355,8 +355,9 @@ class ThumbSrv(object):
                 tex = tpath.rsplit(".", 1)[-1]
                 want_mp3 = tex == "mp3"
                 want_opus = tex in ("opus", "owa", "caf")
+                want_wav = tex == "wav"
                 want_png = tex == "png"
-                want_au = want_mp3 or want_opus
+                want_au = want_mp3 or want_opus or want_wav
                 for lib in self.args.th_dec:
                     can_au = lib == "ff" and (
                         ext in self.fmt_ffa or ext in self.fmt_ffv
@@ -371,6 +372,8 @@ class ThumbSrv(object):
                             funs.append(self.conv_opus)
                         elif want_mp3:
                             funs.append(self.conv_mp3)
+                        elif want_wav:
+                            funs.append(self.conv_wav)
                         elif want_png:
                             funs.append(self.conv_waves)
                             png_ok = True
@@ -580,7 +583,7 @@ class ThumbSrv(object):
         self._run_ff(cmd, vn)
 
     def _run_ff(self, cmd: list[bytes], vn: VFS, oom: int = 400) -> None:
-        # self.log((b" ".join(cmd)).decode("utf-8"))
+        self.log((b" ".join(cmd)).decode("utf-8"))
         ret, _, serr = runcmd(cmd, timeout=vn.flags["convt"], nice=True, oom=oom)
         if not ret:
             return
@@ -805,6 +808,42 @@ class ThumbSrv(object):
             fsenc(tpath)
         ]
         # fmt: on
+        self._run_ff(cmd, vn, oom=300)
+
+    def conv_wav(self, abspath: str, tpath: str, fmt: str, vn: VFS) -> None:
+        if self.args.no_acode or not self.args.q_wav:
+            raise Exception("disabled in server config")
+
+        self.wait4ram(0.2, tpath)
+        tags, rawtags = ffprobe(abspath, int(vn.flags["convt"] / 2))
+        if "ac" not in tags:
+            raise Exception("not audio")
+        
+        bits = tags[".bps"][1]
+        if bits == 0.0:
+            bits = tags[".bprs"][1]
+
+        codec = b"pcm_s32le"
+        if bits == 16.0:
+            codec = b"pcm_s16le"
+        elif bits == 24.0:
+            codec = b"pcm_s24le"
+
+        self.log("conv2 wav-tmp", 6)
+
+        # fmt: off
+        cmd = [
+            b"ffmpeg",
+            b"-nostdin",
+            b"-v", b"error",
+            b"-hide_banner",
+            b"-i", fsenc(abspath),
+            b"-map", b"0:a:0",
+            b"-c:a", codec,
+            fsenc(tpath)
+        ]
+        # fmt: on
+        print(cmd)
         self._run_ff(cmd, vn, oom=300)
 
     def conv_opus(self, abspath: str, tpath: str, fmt: str, vn: VFS) -> None:

--- a/copyparty/web/browser.js
+++ b/copyparty/web/browser.js
@@ -306,6 +306,7 @@ var Ls = {
 		"mt_c2owa": "opus-weba, for iOS 17.5 and newer\">owa",
 		"mt_c2caf": "opus-caf, for iOS 11 through 17\">caf",
 		"mt_c2mp3": "use this on very old devices\">mp3",
+		"mt_c2wav": "use this for uncompressed playback\">wav",
 		"mt_c2ok": "nice, good choice",
 		"mt_c2nd": "that's not the recommended output format for your device, but that's fine",
 		"mt_c2ng": "your device does not seem to support this output format, but let's try anyways",
@@ -5548,6 +5549,7 @@ var mpl = (function () {
 			'<a href="#" id="ac2owa" class="tgl btn" tt="' + L.mt_c2owa + '</a>' +
 			'<a href="#" id="ac2caf" class="tgl btn" tt="' + L.mt_c2caf + '</a>' +
 			'<a href="#" id="ac2mp3" class="tgl btn" tt="' + L.mt_c2mp3 + '</a>' +
+			'<a href="#" id="ac2wav" class="tgl btn" tt="' + L.mt_c2wav + '</a>' +
 			'</div></div>'
 		) : '') +
 
@@ -5663,8 +5665,10 @@ var mpl = (function () {
 
 		if (!have_acode)
 			c = false;
-		else if (/\.(wav|flac)$/i.exec(cs))
+		else if (/\.flac$/i.exec(cs))
 			c = r.ac_flac;
+		else if (/\.wav$/i.exec(cs))
+			c = r.ac_wav;
 		else if (/\.(aac|m4a)$/i.exec(cs))
 			c = r.ac_aac;
 		else if (/\.(oga|ogg|opus)$/i.exec(cs) && (!can_ogg || mpl.ac2 == 'mp3'))
@@ -5688,8 +5692,8 @@ var mpl = (function () {
 			return;
 		}
 
-		var dv = can_ogg ? 'opus' : can_caf ? 'caf' : 'mp3',
-			fmts = ['opus', 'owa', 'caf', 'mp3'],
+		var dv = can_ogg ? 'opus' : can_caf ? 'caf' : can_mp3 ? 'mp3' : 'wav',
+			fmts = ['opus', 'owa', 'caf', 'mp3', 'wav'],
 			btns = [];
 
 		if (v === dv)
@@ -5699,7 +5703,8 @@ var mpl = (function () {
 
 		if ((v == 'opus' && !can_ogg) ||
 			(v == 'caf' && !can_caf) ||
-			(v == 'owa' && !can_owa))
+			(v == 'owa' && !can_owa) ||
+			(v == 'mp3' && !can_mp3))
 			toast.warn(15, L.mt_c2ng);
 
 		if (v == 'owa' && IPHONE)
@@ -5837,11 +5842,13 @@ var mpl = (function () {
 var za,
 	can_ogg = true,
 	can_owa = false,
+	can_mp3 = false,
 	can_caf = APPLE && !/ OS ([1-9]|1[01])_/.test(UA);
 try {
 	za = new Audio();
 	can_ogg = za.canPlayType('audio/ogg; codecs=opus') === 'probably';
 	can_owa = za.canPlayType('audio/webm; codecs=opus') === 'probably';
+	can_mp3 = za.canPlayType('audio/mpeg') === 'probably';
 	can_caf = za.canPlayType('audio/x-caf') && can_caf; //'maybe'
 }
 catch (ex) { }

--- a/copyparty/web/browser.js
+++ b/copyparty/web/browser.js
@@ -306,7 +306,8 @@ var Ls = {
 		"mt_c2owa": "opus-weba, for iOS 17.5 and newer\">owa",
 		"mt_c2caf": "opus-caf, for iOS 11 through 17\">caf",
 		"mt_c2mp3": "use this on very old devices\">mp3",
-		"mt_c2wav": "use this for uncompressed playback\">wav",
+		"mt_c2flac": "best sound quality\">flac",
+		"mt_c2wav": "uncompressed playback\">wav",
 		"mt_c2ok": "nice, good choice",
 		"mt_c2nd": "that's not the recommended output format for your device, but that's fine",
 		"mt_c2ng": "your device does not seem to support this output format, but let's try anyways",
@@ -5549,6 +5550,7 @@ var mpl = (function () {
 			'<a href="#" id="ac2owa" class="tgl btn" tt="' + L.mt_c2owa + '</a>' +
 			'<a href="#" id="ac2caf" class="tgl btn" tt="' + L.mt_c2caf + '</a>' +
 			'<a href="#" id="ac2mp3" class="tgl btn" tt="' + L.mt_c2mp3 + '</a>' +
+			'<a href="#" id="ac2flac" class="tgl btn" tt="' + L.mt_c2flac + '</a>' +
 			'<a href="#" id="ac2wav" class="tgl btn" tt="' + L.mt_c2wav + '</a>' +
 			'</div></div>'
 		) : '') +
@@ -5692,8 +5694,11 @@ var mpl = (function () {
 			return;
 		}
 
-		var dv = can_ogg ? 'opus' : can_caf ? 'caf' : can_mp3 ? 'mp3' : 'wav',
-			fmts = ['opus', 'owa', 'caf', 'mp3', 'wav'],
+		var dv = can_ogg ? 'opus' :
+				can_caf ? 'caf' :
+				can_mp3 ? 'mp3' :
+				can_flac ? 'flac' : 'wav',
+			fmts = ['opus', 'owa', 'caf', 'mp3', 'flac', 'wav'],
 			btns = [];
 
 		if (v === dv)
@@ -5704,7 +5709,8 @@ var mpl = (function () {
 		if ((v == 'opus' && !can_ogg) ||
 			(v == 'caf' && !can_caf) ||
 			(v == 'owa' && !can_owa) ||
-			(v == 'mp3' && !can_mp3))
+			(v == 'mp3' && !can_mp3) ||
+			(v == 'flac' && !can_flac))
 			toast.warn(15, L.mt_c2ng);
 
 		if (v == 'owa' && IPHONE)
@@ -5843,12 +5849,14 @@ var za,
 	can_ogg = true,
 	can_owa = false,
 	can_mp3 = false,
+	can_flac = false,
 	can_caf = APPLE && !/ OS ([1-9]|1[01])_/.test(UA);
 try {
 	za = new Audio();
 	can_ogg = za.canPlayType('audio/ogg; codecs=opus') === 'probably';
 	can_owa = za.canPlayType('audio/webm; codecs=opus') === 'probably';
 	can_mp3 = za.canPlayType('audio/mpeg') === 'probably';
+	can_flac = za.canPlayType('audio/flac') === 'probably';
 	can_caf = za.canPlayType('audio/x-caf') && can_caf; //'maybe'
 }
 catch (ex) { }

--- a/scripts/tl.js
+++ b/scripts/tl.js
@@ -390,6 +390,8 @@ var tl_browser = {
 		"mt_c2owa": "opus-weba, for iOS 17.5 and newer\">owa",
 		"mt_c2caf": "opus-caf, for iOS 11 through 17\">caf",
 		"mt_c2mp3": "use this on very old devices\">mp3",
+		"mt_c2flac": "best sound quality\">flac",
+		"mt_c2wav": "uncompressed playback\">wav",
 		"mt_c2ok": "nice, good choice",
 		"mt_c2nd": "that's not the recommended output format for your device, but that's fine",
 		"mt_c2ng": "your device does not seem to support this output format, but let's try anyways",


### PR DESCRIPTION
### _tl;dr this pull request adds the ability to transcode to wav and flac formats for alac support_

hey!

this pull request opens the gate for copyparty to be more versatile and flexible in its codecs. by adding the option to transcode to flac and wav codecs, files with apple's alac codec can now be played directly from the browser, without any sort of quality loss.

alac has not been adopted in modern browsers today. while it's nearly identical to flac, it's support has been neglected by every browser except apple's own safari. because alac, flac and wav are so similar, we can transcode super easily between each other with no quality loss. 

transcoding to wav is crucial since it's support has been around for [ages](https://caniuse.com/wav). giving even the oldest browsers and systems, the ability to play back even the highest sample rates. 
transcoding to wav can also be extremely handy for other codecs like mp3! if a user were to play an opus file and the browser didnt support it, it would have to be transcoded to mp3. thats 2 sets of audio compression resulting in lower fidelity. if the user were to click transcode to wav, they would be able to play back the opus files contents with no degraded quality.

i wish that that you merge this pr to help with audio fidelity in your software.

many thanks

_This PR complies with the DCO; https://developercertificate.org/_  
