### PR TITLE
Fix link copying bug in upload interface

### DIFF
--- a/copyparty/web/up2k.js
+++ b/copyparty/web/up2k.js
@@ -1595,7 +1595,7 @@ function up2k_init(subtle) {
         ev(e);
         var txt = linklist();
         cliptxt(txt + '\n', function () {
-            toast.inf(5, un_clip.format(txt.split('\n').length));
+            toast.inf(5, L.un_clip.format(txt.split('\n').length));
         });
     };
 


### PR DESCRIPTION
Fixes #467

 ## Summary
- Adds missing `L.` prefix to `un_clip` localization string in `up2k.js:1598`

---

To show that your contribution is compatible with the MIT License, please include the following text somewhere in this PR description:  
This PR complies with the DCO; https://developercertificate.org/  
