### PR TITLE
Add .idea to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ scripts/docker/*.err
 
 # nix build output link
 result
+
+# IDEA config
+.idea/


### PR DESCRIPTION
Add .idea to the gitignore file for people who develop with PyCharm.

This PR complies with the DCO; https://developercertificate.org/  
