### PR TITLE
fix PRTY_CONFIG not reading global flags from the config

### DIFF
--- a/copyparty/__main__.py
+++ b/copyparty/__main__.py
@@ -1767,6 +1767,10 @@ def main(argv: Optional[list[str]] = None) -> None:
 
     ensure_webdeps()
 
+    if CFG_DEF:
+        supp = args_from_cfg(CFG_DEF[0])
+        argv.extend(supp)
+
     for k, v in zip(argv[1:], argv[2:]):
         if k == "-c" and os.path.isfile(v):
             supp = args_from_cfg(v)


### PR DESCRIPTION
This PR complies with the DCO; https://developercertificate.org/  

the systemd services are currently broken on the arch package since they use PRTY_CONFIG to get the configuration path, and PRTY_CONFIG currently doesn't seem to read anything in the [global] section of the configuration file at all (though it seems to get the account and volume stuff just fine)

after approximately nine gorillion hours of debugging i came up with this which seems to work, though i'm still not entirely sure why