### PR TITLE
Add missing translated string in up2k.

### DIFF
--- a/copyparty/web/up2k.js
+++ b/copyparty/web/up2k.js
@@ -2831,7 +2831,7 @@ function up2k_init(subtle) {
         if (!t.t_uploading)
             t.t_uploading = Date.now();
 
-        pvis.seth(t.n, 1, "🚀 send");
+        pvis.seth(t.n, 1, "🚀 " + L.ul_send);
 
         var chunksize = get_chunksize(t.size),
             car = pcar * chunksize,


### PR DESCRIPTION
The translation for the string used in up2k for when an upload is sending data was not actually used.

To show that your contribution is compatible with the MIT License, please include the following text somewhere in this PR description:  
This PR complies with the DCO; https://developercertificate.org/  
