### PR TITLE
EPUB Thumbnailing support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2270,10 +2270,10 @@ example: `PRTY_NO_IFADDR=1 python3 copyparty-sfx.py`
 
 force-enable features with known issues on your OS/env  by setting any of the following environment variables, also affectionately known as `fuckitbits` or `hail-mary-bits`
 
-| env-var                     | what it does                                                                                                                                                        |
-|-----------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `PRTY_FORCE_MP`             | force-enable multiprocessing (real multithreading) on MacOS and other broken platforms                                                                              |
-| `PRTY_FORCE_MAGIC`          | use [magic](https://pypi.org/project/python-magic/) on Windows (you will segfault)                                                                                  |
+| env-var                  | what it does |
+| ------------------------ | ------------ |
+| `PRTY_FORCE_MP`          | force-enable multiprocessing (real multithreading) on MacOS and other broken platforms |
+| `PRTY_FORCE_MAGIC`       | use [magic](https://pypi.org/project/python-magic/) on Windows (you will segfault) |
 
 
 # packages

--- a/README.md
+++ b/README.md
@@ -2270,10 +2270,11 @@ example: `PRTY_NO_IFADDR=1 python3 copyparty-sfx.py`
 
 force-enable features with known issues on your OS/env  by setting any of the following environment variables, also affectionately known as `fuckitbits` or `hail-mary-bits`
 
-| env-var                  | what it does |
-| ------------------------ | ------------ |
-| `PRTY_FORCE_MP`          | force-enable multiprocessing (real multithreading) on MacOS and other broken platforms |
-| `PRTY_FORCE_MAGIC`       | use [magic](https://pypi.org/project/python-magic/) on Windows (you will segfault) |
+| env-var                     | what it does                                                                                                                                                        |
+|-----------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `PRTY_FORCE_MP`             | force-enable multiprocessing (real multithreading) on MacOS and other broken platforms                                                                              |
+| `PRTY_FORCE_MAGIC`          | use [magic](https://pypi.org/project/python-magic/) on Windows (you will segfault)                                                                                  |
+| `PRTY_ALLOW_INSECURE_EXPAT` | allow using expat versions (bundled with python) that are vulnerable to xml attacks, [see the python docs](https://docs.python.org/3/library/xml.html#xml-security) |
 
 
 # packages

--- a/README.md
+++ b/README.md
@@ -2274,7 +2274,6 @@ force-enable features with known issues on your OS/env  by setting any of the fo
 |-----------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `PRTY_FORCE_MP`             | force-enable multiprocessing (real multithreading) on MacOS and other broken platforms                                                                              |
 | `PRTY_FORCE_MAGIC`          | use [magic](https://pypi.org/project/python-magic/) on Windows (you will segfault)                                                                                  |
-| `PRTY_ALLOW_INSECURE_EXPAT` | allow using expat versions (bundled with python) that are vulnerable to xml attacks, [see the python docs](https://docs.python.org/3/library/xml.html#xml-security) |
 
 
 # packages

--- a/copyparty/__main__.py
+++ b/copyparty/__main__.py
@@ -1443,13 +1443,13 @@ def add_thumbnail(ap):
     # https://pillow.readthedocs.io/en/stable/handbook/image-file-formats.html
     # https://github.com/libvips/libvips
     # ffmpeg -hide_banner -demuxers | awk '/^ D  /{print$2}' | while IFS= read -r x; do ffmpeg -hide_banner -h demuxer=$x; done | grep -E '^Demuxer |extensions:'
-    ap2.add_argument("--th-r-pil", metavar="T,T", type=u, default="avif,avifs,blp,bmp,cbz,dcx,dds,dib,emf,eps,fits,flc,fli,fpx,gif,heic,heics,heif,heifs,icns,ico,im,j2p,j2k,jp2,jpeg,jpg,jpx,pbm,pcx,pgm,png,pnm,ppm,psd,qoi,sgi,spi,tga,tif,tiff,webp,wmf,xbm,xpm", help="image formats to decode using pillow")
+    ap2.add_argument("--th-r-pil", metavar="T,T", type=u, default="avif,avifs,blp,bmp,cbz,dcx,dds,dib,emf,eps,epub,fits,flc,fli,fpx,gif,heic,heics,heif,heifs,icns,ico,im,j2p,j2k,jp2,jpeg,jpg,jpx,pbm,pcx,pgm,png,pnm,ppm,psd,qoi,sgi,spi,tga,tif,tiff,webp,wmf,xbm,xpm", help="image formats to decode using pillow")
     ap2.add_argument("--th-r-vips", metavar="T,T", type=u, default="avif,exr,fit,fits,fts,gif,hdr,heic,jp2,jpeg,jpg,jpx,jxl,nii,pfm,pgm,png,ppm,svg,tif,tiff,webp", help="image formats to decode using pyvips")
-    ap2.add_argument("--th-r-ffi", metavar="T,T", type=u, default="apng,avif,avifs,bmp,cbz,dds,dib,fit,fits,fts,gif,hdr,heic,heics,heif,heifs,icns,ico,jp2,jpeg,jpg,jpx,jxl,pbm,pcx,pfm,pgm,png,pnm,ppm,psd,qoi,sgi,tga,tif,tiff,webp,xbm,xpm", help="image formats to decode using ffmpeg")
+    ap2.add_argument("--th-r-ffi", metavar="T,T", type=u, default="apng,avif,avifs,bmp,cbz,dds,dib,epub,fit,fits,fts,gif,hdr,heic,heics,heif,heifs,icns,ico,jp2,jpeg,jpg,jpx,jxl,pbm,pcx,pfm,pgm,png,pnm,ppm,psd,qoi,sgi,tga,tif,tiff,webp,xbm,xpm", help="image formats to decode using ffmpeg")
     ap2.add_argument("--th-r-ffv", metavar="T,T", type=u, default="3gp,asf,av1,avc,avi,flv,h264,h265,hevc,m4v,mjpeg,mjpg,mkv,mov,mp4,mpeg,mpeg2,mpegts,mpg,mpg2,mts,nut,ogm,ogv,rm,ts,vob,webm,wmv", help="video formats to decode using ffmpeg")
     ap2.add_argument("--th-r-ffa", metavar="T,T", type=u, default="aac,ac3,aif,aiff,alac,alaw,amr,apac,ape,au,bonk,dfpwm,dts,flac,gsm,ilbc,it,itgz,itxz,itz,m4a,mdgz,mdxz,mdz,mo3,mod,mp2,mp3,mpc,mptm,mt2,mulaw,oga,ogg,okt,opus,ra,s3m,s3gz,s3xz,s3z,tak,tta,ulaw,wav,wma,wv,xm,xmgz,xmxz,xmz,xpk", help="audio formats to decode using ffmpeg")
     ap2.add_argument("--th-spec-cnv", metavar="T", type=u, default="it,itgz,itxz,itz,mdgz,mdxz,mdz,mo3,mod,s3m,s3gz,s3xz,s3z,xm,xmgz,xmxz,xmz,xpk", help="audio formats which provoke https://trac.ffmpeg.org/ticket/10797 (huge ram usage for s3xmodit spectrograms)")
-    ap2.add_argument("--au-unpk", metavar="E=F.C", type=u, default="mdz=mod.zip, mdgz=mod.gz, mdxz=mod.xz, s3z=s3m.zip, s3gz=s3m.gz, s3xz=s3m.xz, xmz=xm.zip, xmgz=xm.gz, xmxz=xm.xz, itz=it.zip, itgz=it.gz, itxz=it.xz, cbz=jpg.cbz", help="audio/image formats to decompress before passing to ffmpeg")
+    ap2.add_argument("--au-unpk", metavar="E=F.C", type=u, default="mdz=mod.zip, mdgz=mod.gz, mdxz=mod.xz, s3z=s3m.zip, s3gz=s3m.gz, s3xz=s3m.xz, xmz=xm.zip, xmgz=xm.gz, xmxz=xm.xz, itz=it.zip, itgz=it.gz, itxz=it.xz, cbz=jpg.cbz, epub=jpg.epub", help="audio/image formats to decompress before passing to ffmpeg")
 
 
 def add_transcoding(ap):

--- a/copyparty/dxml.py
+++ b/copyparty/dxml.py
@@ -65,6 +65,9 @@ DXMLParser = _DXMLParser
 
 
 def parse_xml(txt: str) -> ET.Element:
+    """
+    Parse XML into an xml.etree.ElementTree.Element while defusing some unsafe parts.
+    """
     parser = DXMLParser()
     parser.feed(txt)
     return parser.close()  # type: ignore

--- a/copyparty/mtag.py
+++ b/copyparty/mtag.py
@@ -29,7 +29,7 @@ from .util import (
 )
 
 if True:  # pylint: disable=using-constant-test
-    from typing import Any, Optional, Union, IO
+    from typing import IO, Any, Optional, Union
 
     from .util import NamedLogger, RootLogger
 
@@ -59,6 +59,7 @@ def have_ff(scmd: str) -> bool:
             return False
     else:
         return bool(shutil.which(scmd))
+
 
 HAVE_FFMPEG = not os.environ.get("PRTY_NO_FFMPEG") and have_ff("ffmpeg")
 HAVE_FFPROBE = not os.environ.get("PRTY_NO_FFPROBE") and have_ff("ffprobe")
@@ -369,7 +370,9 @@ def parse_ffprobe(txt: str) -> tuple[dict[str, tuple[int, Any]], dict[str, list[
 
 def get_cover_from_epub(log: "NamedLogger", abspath: str) -> IO[bytes] | None:
     import zipfile
+
     from .dxml import parse_xml
+
     try:
         from urlparse import urljoin  # Python2
     except ImportError:
@@ -380,33 +383,34 @@ def get_cover_from_epub(log: "NamedLogger", abspath: str) -> IO[bytes] | None:
         try:
             container_root = parse_xml(z.read("META-INF/container.xml").decode())
         except KeyError:
-            log(f"epub: no container file found in {abspath}")
+            log("epub: no container file found in %s" % (abspath,))
             return None
 
         # https://www.w3.org/TR/epub-33/#sec-container.xml-rootfile-elem
-        container_namespace = {"": "urn:oasis:names:tc:opendocument:xmlns:container"}
+        container_ns = {"": "urn:oasis:names:tc:opendocument:xmlns:container"}
         # One file could contain multiple package documents, default to the first one
-        rootfile_path = container_root\
-            .find("./rootfiles/rootfile", container_namespace)\
-            .get("full-path")
+        rootfile_path = container_root.find("./rootfiles/rootfile", container_ns).get(
+            "full-path"
+        )
 
         # Then open the first package document to find the path of the cover image
         try:
             package_root = parse_xml(z.read(rootfile_path).decode())
         except KeyError:
-            log(f"epub: no package document found in {abspath}")
+            log("epub: no package document found in %s" % (abspath,))
             return None
 
         # https://www.w3.org/TR/epub-33/#sec-package-doc
-        package_namespaces = {"": "http://www.idpf.org/2007/opf"}
+        package_ns = {"": "http://www.idpf.org/2007/opf"}
         # https://www.w3.org/TR/epub-33/#sec-cover-image
-        coverimage_path_node = package_root\
-            .find("./manifest/item[@properties='cover-image']", package_namespaces)
-        if coverimage_path_node:
+        coverimage_path_node = package_root.find(
+            "./manifest/item[@properties='cover-image']", package_ns
+        )
+        if coverimage_path_node is not None:
             coverimage_path = coverimage_path_node.get("href")
         else:
             # This might be an EPUB2 file, try the legacy way of specifying covers
-            coverimage_path = _get_cover_from_epub2(log, package_root, package_namespaces)
+            coverimage_path = _get_cover_from_epub2(log, package_root, package_ns)
 
         # This url is either absolute (in the .epub) or relative to the package document
         adjusted_cover_path = urljoin(rootfile_path, coverimage_path)
@@ -414,16 +418,17 @@ def get_cover_from_epub(log: "NamedLogger", abspath: str) -> IO[bytes] | None:
         return z.open(adjusted_cover_path)
 
 
-def _get_cover_from_epub2(log: "NamedLogger", package_root, package_namespaces) -> str | None:
+def _get_cover_from_epub2(log: "NamedLogger", package_root, package_ns) -> str | None:
     # <meta name="cover" content="id-to-cover-image"> in <metadata>, then
     # <item> in <manifest>
-    cover_id = package_root \
-        .find("./metadata/meta[@name='cover']", package_namespaces) \
-        .get("content")
+    cover_id = package_root.find("./metadata/meta[@name='cover']", package_ns).get(
+        "content"
+    )
+
     if not cover_id:
         return None
 
-    for node in package_root.iterfind("./manifest/item", package_namespaces):
+    for node in package_root.iterfind("./manifest/item", package_ns):
         if node.get("id") == cover_id:
             cover_path = node.get("href")
             return cover_path

--- a/copyparty/mtag.py
+++ b/copyparty/mtag.py
@@ -29,7 +29,7 @@ from .util import (
 )
 
 if True:  # pylint: disable=using-constant-test
-    from typing import Any, Optional, Union
+    from typing import Any, Optional, Union, IO
 
     from .util import NamedLogger, RootLogger
 
@@ -60,9 +60,23 @@ def have_ff(scmd: str) -> bool:
     else:
         return bool(shutil.which(scmd))
 
+def expat_is_secure():
+    """
+    From the python xml docs:
+
+    An attacker can abuse XML features to carry out denial of service attacks, access local files, generate network connections to other machines, or circumvent firewalls.
+    Expat versions lower that 2.6.0 may be vulnerable to “billion laughs”, “quadratic blowup” and “large tokens”. Python may be vulnerable if it uses such older versions of Expat as a system-provided library. Check pyexpat.EXPAT_VERSION.
+    """
+    import pyexpat
+    # expat_2.7.1
+    if len(pyexpat.EXPAT_VERSION) < 11:
+        return False
+    major, minor, patch = (int(x) for x in pyexpat.EXPAT_VERSION[6:].split("."))
+    return major > 2 or major == 2 and minor >= 6
 
 HAVE_FFMPEG = not os.environ.get("PRTY_NO_FFMPEG") and have_ff("ffmpeg")
 HAVE_FFPROBE = not os.environ.get("PRTY_NO_FFPROBE") and have_ff("ffprobe")
+HAVE_SECURE_EXPAT = os.environ.get("PRTY_ALLOW_INSECURE_EXPAT") or expat_is_secure()
 
 CBZ_PICS = set("png jpg jpeg gif bmp tga tif tiff webp avif".split())
 CBZ_01 = re.compile(r"(^|[^0-9v])0+[01]\b")
@@ -175,6 +189,10 @@ def au_unpk(
             if not znil:
                 raise Exception("no images inside cbz")
             fi = zf.open(using)
+
+        elif pk == "epub":
+            if HAVE_SECURE_EXPAT:
+                fi = get_cover_from_epub(log, abspath)
 
         else:
             raise Exception("unknown compression %s" % (pk,))
@@ -365,6 +383,70 @@ def parse_ffprobe(txt: str) -> tuple[dict[str, tuple[int, Any]], dict[str, list[
     return zd, md
 
 
+def get_cover_from_epub(log: "NamedLogger", abspath: str) -> IO[bytes] | None:
+    import zipfile
+    import xml.etree.ElementTree as ElTree
+    try:
+        from urlparse import urljoin  # Python2
+    except ImportError:
+        from urllib.parse import urljoin  # Python3
+
+    with zipfile.ZipFile(abspath, "r") as z:
+        # First open the container file to find the package document (.opf file)
+        try:
+            container_root = ElTree.parse(z.open("META-INF/container.xml"))
+        except KeyError:
+            log(f"epub: no container file found in {abspath}")
+            return None
+
+        # https://www.w3.org/TR/epub-33/#sec-container.xml-rootfile-elem
+        container_namesapce = {"": "urn:oasis:names:tc:opendocument:xmlns:container"}
+        # One file could contain multiple package documents, default to the first one
+        rootfile_path = container_root\
+            .find("./rootfiles/rootfile", container_namesapce)\
+            .get("full-path")
+
+        # Then open the first package document to find the path of the cover image
+        try:
+            package_root = ElTree.parse(z.open(rootfile_path))
+        except KeyError:
+            log(f"epub: no package document found in {abspath}")
+            return None
+
+        # https://www.w3.org/TR/epub-33/#sec-package-doc
+        package_namespaces = {"": "http://www.idpf.org/2007/opf"}
+        # https://www.w3.org/TR/epub-33/#sec-cover-image
+        coverimage_path_node = package_root\
+            .find("./manifest/item[@properties='cover-image']", package_namespaces)
+        if coverimage_path_node:
+            coverimage_path = coverimage_path_node.get("href")
+        else:
+            # This might be an EPUB2 file, try the legacy way of specifying covers
+            coverimage_path = _get_cover_from_epub2(log, package_root, package_namespaces)
+
+        # This url is either absolute (in the .epub) or relative to the package document
+        adjusted_cover_path = urljoin(rootfile_path, coverimage_path)
+
+        return z.open(adjusted_cover_path)
+
+
+def _get_cover_from_epub2(log: "NamedLogger", package_root, package_namespaces) -> str | None:
+    # <meta name="cover" content="id-to-cover-image"> in <metadata>, then
+    # <item> in <manifest>
+    cover_id = package_root \
+        .find("./metadata/meta[@name='cover']", package_namespaces) \
+        .get("content")
+    if not cover_id:
+        return None
+
+    for node in package_root.iterfind("./manifest/item", package_namespaces):
+        if node.get("id") == cover_id:
+            cover_path = node.get("href")
+            return cover_path
+
+    return None
+
+
 class MTag(object):
     def __init__(self, log_func: "RootLogger", args: argparse.Namespace) -> None:
         self.log_func = log_func
@@ -406,6 +488,9 @@ class MTag(object):
             pyname = os.path.basename(pybin)
             self.log(msg.format(or_ffprobe, " " * 37, pyname), c=1)
             return
+
+        if not HAVE_SECURE_EXPAT:
+            self.log("expat version is missing critical security fixes; epub thumbnails will not be available", c=3)
 
         # https://picard-docs.musicbrainz.org/downloads/MusicBrainz_Picard_Tag_Map.html
         tagmap = {

--- a/copyparty/mtag.py
+++ b/copyparty/mtag.py
@@ -60,23 +60,8 @@ def have_ff(scmd: str) -> bool:
     else:
         return bool(shutil.which(scmd))
 
-def expat_is_secure():
-    """
-    From the python xml docs:
-
-    An attacker can abuse XML features to carry out denial of service attacks, access local files, generate network connections to other machines, or circumvent firewalls.
-    Expat versions lower that 2.6.0 may be vulnerable to “billion laughs”, “quadratic blowup” and “large tokens”. Python may be vulnerable if it uses such older versions of Expat as a system-provided library. Check pyexpat.EXPAT_VERSION.
-    """
-    import pyexpat
-    # expat_2.7.1
-    if len(pyexpat.EXPAT_VERSION) < 11:
-        return False
-    major, minor, patch = (int(x) for x in pyexpat.EXPAT_VERSION[6:].split("."))
-    return major > 2 or major == 2 and minor >= 6
-
 HAVE_FFMPEG = not os.environ.get("PRTY_NO_FFMPEG") and have_ff("ffmpeg")
 HAVE_FFPROBE = not os.environ.get("PRTY_NO_FFPROBE") and have_ff("ffprobe")
-HAVE_SECURE_EXPAT = os.environ.get("PRTY_ALLOW_INSECURE_EXPAT") or expat_is_secure()
 
 CBZ_PICS = set("png jpg jpeg gif bmp tga tif tiff webp avif".split())
 CBZ_01 = re.compile(r"(^|[^0-9v])0+[01]\b")
@@ -191,8 +176,7 @@ def au_unpk(
             fi = zf.open(using)
 
         elif pk == "epub":
-            if HAVE_SECURE_EXPAT:
-                fi = get_cover_from_epub(log, abspath)
+            fi = get_cover_from_epub(log, abspath)
 
         else:
             raise Exception("unknown compression %s" % (pk,))
@@ -385,7 +369,7 @@ def parse_ffprobe(txt: str) -> tuple[dict[str, tuple[int, Any]], dict[str, list[
 
 def get_cover_from_epub(log: "NamedLogger", abspath: str) -> IO[bytes] | None:
     import zipfile
-    import xml.etree.ElementTree as ElTree
+    from .dxml import parse_xml
     try:
         from urlparse import urljoin  # Python2
     except ImportError:
@@ -394,21 +378,21 @@ def get_cover_from_epub(log: "NamedLogger", abspath: str) -> IO[bytes] | None:
     with zipfile.ZipFile(abspath, "r") as z:
         # First open the container file to find the package document (.opf file)
         try:
-            container_root = ElTree.parse(z.open("META-INF/container.xml"))
+            container_root = parse_xml(z.read("META-INF/container.xml").decode())
         except KeyError:
             log(f"epub: no container file found in {abspath}")
             return None
 
         # https://www.w3.org/TR/epub-33/#sec-container.xml-rootfile-elem
-        container_namesapce = {"": "urn:oasis:names:tc:opendocument:xmlns:container"}
+        container_namespace = {"": "urn:oasis:names:tc:opendocument:xmlns:container"}
         # One file could contain multiple package documents, default to the first one
         rootfile_path = container_root\
-            .find("./rootfiles/rootfile", container_namesapce)\
+            .find("./rootfiles/rootfile", container_namespace)\
             .get("full-path")
 
         # Then open the first package document to find the path of the cover image
         try:
-            package_root = ElTree.parse(z.open(rootfile_path))
+            package_root = parse_xml(z.read(rootfile_path).decode())
         except KeyError:
             log(f"epub: no package document found in {abspath}")
             return None
@@ -488,9 +472,6 @@ class MTag(object):
             pyname = os.path.basename(pybin)
             self.log(msg.format(or_ffprobe, " " * 37, pyname), c=1)
             return
-
-        if not HAVE_SECURE_EXPAT:
-            self.log("expat version is missing critical security fixes; epub thumbnails will not be available", c=3)
 
         # https://picard-docs.musicbrainz.org/downloads/MusicBrainz_Picard_Tag_Map.html
         tagmap = {


### PR DESCRIPTION

<img width="951" height="369" alt="image" src="https://github.com/user-attachments/assets/a4ec18a7-1550-4ea7-8764-b14be2d5ac76" />

Supports both EPUB 3 and EPUB 2. The latter doesn't have a formal standard for cover images, but this implementation seems to be quite common.

HAVE_SECURE_EXPAT is required because EPUB is XML, and parsing XML is insecure otherwise. This might mean some old versions of python can't get EPUB thumbnails, except for force-enabling it. I'd like some more eyes on that, if possible.

cc #234 

This PR complies with the DCO; https://developercertificate.org/  
