### PR TITLE
Simplify reverse proxy path handling in redirect()

### DIFF
--- a/copyparty/httpcli.py
+++ b/copyparty/httpcli.py
@@ -1106,7 +1106,18 @@ class HttpCli(object):
         status: int = 200,
         use302: bool = False,
     ) -> bool:
-        vp = self.args.SRS + vpath
+        if self.args.R:
+            if vpath.startswith(self.args.SR):
+                vp = vpath
+            elif vpath.startswith("/"):
+                vp = self.args.SR + vpath
+            else:
+                vp = self.args.SRS + vpath
+        else:
+            if vpath.startswith("/"):
+                vp = vpath
+            else:
+                vp = "/" + vpath if vpath else "/"
         html = self.j2s(
             "msg",
             h2='<a href="{}">{} {}</a>'.format(


### PR DESCRIPTION
Remove redundant SRS check since SRS paths always start with SR. The first condition (SRS) is redundant because SRS = SR + "/", so any path starting with SRS will also start with SR.

Closes #306(9001/copyparty#306)

To show that your contribution is compatible with the MIT License, please include the following text somewhere in this PR description:  
This PR complies with the DCO; https://developercertificate.org/  
