### PR TITLE
warn if failed to import pyvips

### DIFF
--- a/copyparty/th_srv.py
+++ b/copyparty/th_srv.py
@@ -113,14 +113,17 @@ except:
 
 try:
     if os.environ.get("PRTY_NO_VIPS"):
-        raise Exception()
+        raise ImportError()
 
     HAVE_VIPS = True
     import pyvips
 
     logging.getLogger("pyvips").setLevel(logging.WARNING)
-except:
+except Exception as e:
     HAVE_VIPS = False
+    if not isinstance(e, ImportError):
+        logging.warning("libvips found, but failed to load: " + str(e))
+
 
 try:
     if os.environ.get("PRTY_NO_RAW"):


### PR DESCRIPTION
pyvips uses `ffi.callback()`, which [is not supported on on some systems](https://cffi.readthedocs.io/en/latest/using.html#callbacks), causing copyparty quietly fail to import it.

## Testing
```sh
$ systemd-run -t -p MemoryDenyWriteExecute=true copyparty
WARNING:root:libvips found, but failed to load: Cannot allocate write+execute memory for ffi.callback(). You might be running on a system that prevents this. For more information, see https://cffi.readthedocs.io/en/latest/using.html#callbacks
```
<sub>This PR complies with the DCO; https://developercertificate.org/</sub>
