### PR TITLE
readme: fix nixos overlay usage docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2390,7 +2390,7 @@ in
   imports = [ "${copyparty}/contrib/nixos/modules/copyparty.nix" ];
 
   # add the copyparty overlay to expose the package to the module
-  nixpkgs.overlays = [ "${copyparty}/contrib/package/nix/overlay.nix" ];
+  nixpkgs.overlays = [ (import "${copyparty}/contrib/package/nix/overlay.nix") ];
   # (optional) install the package globally
   environment.systemPackages = [ pkgs.copyparty ];
   # configure the copyparty module


### PR DESCRIPTION
accidentally made a mistake in #296 with the readme documentation - you need to import the overlay instead of just passing the path to `nixpkgs.overlays`. my bad! this pr fixes up that mistake.

this pr complies with the dco; https://developercertificate.org/  
