### PR TITLE
bubbleparty.sh: process substitution requires bash

### DIFF
--- a/bin/bubbleparty.sh
+++ b/bin/bubbleparty.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # usage: ./bubbleparty.sh ./copyparty-sfx.py ....
 bwrap \
   --unshare-all \


### PR DESCRIPTION
POSIX shell does not yet support  `<(process substitution)`.

Reference: [Shell Command Language, 2024](https://pubs.opengroup.org/onlinepubs/9799919799/)

This PR complies with the DCO; https://developercertificate.org/  
