### PR TITLE
ftpd: Use implicit FTPS instead of explicit

### DIFF
--- a/copyparty/ftpd.py
+++ b/copyparty/ftpd.py
@@ -564,6 +564,16 @@ try:
     class SftpHandler(FtpHandler, TLS_FTPHandler):
         pass
 
+    class FtpsImplicitHandler(FtpHandler, TLS_FTPHandler):
+        def handle(self):
+            self.secure_connection(self.ssl_context)
+
+        def handle_ssl_established(self):
+            FtpHandler.handle(self)
+
+        def ftp_AUTH(self, arg):
+            self.respond("550 not supposed to be used with implicit SSL.")
+
 except:
     pass
 
@@ -578,7 +588,7 @@ class Ftpd(object):
             hs.append([FtpHandler, self.args.ftp])
         if self.args.ftps:
             try:
-                h1 = SftpHandler
+                h1 = FtpsImplicitHandler
             except:
                 t = "\nftps requires pyopenssl;\nplease run the following:\n\n  {} -m pip install --user pyopenssl\n"
                 print(t.format(pybin))


### PR DESCRIPTION
This PRs intent is to show it is possible to use implicit FTP over TLS with pyftpdlib.

Implementation found in https://github.com/giampaolo/pyftpdlib/commit/edbc9ccaaac7beccd4a2c0ea5ffb56a9512ba02c

This PR complies with the DCO; https://developercertificate.org/