### PR TITLE
Added globalExtraConfig option to the NixOS Module

### DIFF
--- a/contrib/nixos/modules/copyparty.nix
+++ b/contrib/nixos/modules/copyparty.nix
@@ -135,7 +135,7 @@ in
     globalExtraConfig = mkOption {
       type = types.str;
       default = "";
-      description = "Appened to the end of the [global] section verbatim. This is useful for flags which are used in a repeating manner (e.g. ipu: 255.255.255.1=user) which can't be repeated in the settings = {} attribute set.";
+      description = "Appended to the end of the [global] section verbatim. This is useful for flags which are used in a repeating manner (e.g. ipu: 255.255.255.1=user) which can't be repeated in the settings = {} attribute set.";
     };
 
     accounts = mkOption {

--- a/contrib/nixos/modules/copyparty.nix
+++ b/contrib/nixos/modules/copyparty.nix
@@ -50,6 +50,7 @@ let
 
   configStr = ''
     ${mkSection "global" cfg.settings}
+    ${cfg.globalExtraConfig}
     ${mkSection "accounts" (accountsWithPlaceholders cfg.accounts)}
     ${concatStringsSep "\n" (mapAttrsToList mkVolume cfg.volumes)}
   '';
@@ -129,6 +130,12 @@ in
           hist = ${externalCacheDir};
         }
       '';
+    };
+
+    globalExtraConfig = mkOption {
+      type = types.str;
+      default = "";
+      description = "Appened to the end of the [global] section verbatim. This is useful for flags which are used in a repeating manner (e.g. ipu: 255.255.255.1=user) which can't be repeated in the settings = {} attribute set.";
     };
 
     accounts = mkOption {
@@ -373,3 +380,4 @@ in
     }
   );
 }
+


### PR DESCRIPTION
Added in an option, 'services.copyparty.globalExtraConfig', with default value and description to the NixOS Module. The option type is 'str' and the default value is the empty string.

This string is appended verbatim to the [global] section of the config. This allows the use of settings which rely on repeated values to be correctly used. For example, the: 'ipu: 255.255.255.1/32=user' key which allows automatic sign in for users of a CIDR subnet. Because attribute sets in Nix must have unique keys, it is not possible to set more than one CIDR subnet/user pair.

'extraConfig' options are common in many Nix modules, providing a simple and familiar configuration which is also flexible for future options.

To show that your contribution is compatible with the MIT License, please include the following text somewhere in this PR description:  
This PR complies with the DCO; https://developercertificate.org/  
