### PR TITLE
Change seek 10sec ahead shortcut from 'P' to 'O' in help box.

### DIFF
--- a/copyparty/web/baguettebox.js
+++ b/copyparty/web/baguettebox.js
@@ -253,7 +253,7 @@ window.baguetteBox = (function () {
             ['S', 'toggle file selection'],
             ['space, P, K', 'video: play / pause'],
             ['U', 'video: seek 10sec back'],
-            ['P', 'video: seek 10sec ahead'],
+            ['O', 'video: seek 10sec ahead'],
             ['0..9', 'video: seek 0%..90%'],
             ['M', 'video: toggle mute'],
             ['V', 'video: toggle loop'],


### PR DESCRIPTION
Just a small fix in the help box of video player. This is only changing what is displayed in the help box, not changing the actual key shortcut. 

To show that your contribution is compatible with the MIT License, please include the following text somewhere in this PR description:  
This PR complies with the DCO; https://developercertificate.org/  
