### PR TITLE
(copyparty.service) Update binary path

### DIFF
--- a/contrib/package/makedeb-mpr/copyparty.service
+++ b/contrib/package/makedeb-mpr/copyparty.service
@@ -26,7 +26,7 @@ Environment=XDG_CONFIG_HOME=/home/cpp/.config
 ExecStartPre=+/bin/bash -c 'mkdir -p /run/tmpfiles.d/ && echo "x /tmp/pe-copyparty*" > /run/tmpfiles.d/copyparty.conf'
 
 # run copyparty
-ExecStart=/usr/bin/python3 /usr/bin/copyparty -c /etc/copyparty.d/init
+ExecStart=/usr/bin/python3 /usr/local/bin/copyparty -c /etc/copyparty.d/init
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
for some reason, apt installs copyparty to /usr/local/bin now. i don't know what changed, but the service needs to be different on this platform now bc of that

This PR complies with the DCO; https://developercertificate.org/  
