### PR TITLE
Add groups to nix config

### DIFF
--- a/contrib/nixos/modules/copyparty.nix
+++ b/contrib/nixos/modules/copyparty.nix
@@ -52,6 +52,7 @@ let
     ${mkSection "global" cfg.settings}
     ${cfg.globalExtraConfig}
     ${mkSection "accounts" (accountsWithPlaceholders cfg.accounts)}
+    ${mkSection "groups" cfg.groups}
     ${concatStringsSep "\n" (mapAttrsToList mkVolume cfg.volumes)}
   '';
 
@@ -163,6 +164,19 @@ in
       example = literalExpression ''
         {
           ed.passwordFile = "/run/keys/copyparty/ed";
+        };
+      '';
+    };
+
+    groups = mkOption {
+      type = types.attrsOf (types.listOf types.str);
+      description = ''
+        A set of copyparty groups to create and the users that should be part of each group.
+      '';
+      default = { };
+      example = literalExpression ''
+        {
+          group_name = [ "user1" "user2" ];
         };
       '';
     };


### PR DESCRIPTION
Pretty small change.

The current nixos config does not allow the definition of groups.  
This PR remedies it.  
There are still more configuration values that cannot be made with the current nixos module, specifically places where the same value has to be provided multiple times.  
My skills with nixos modules not good enough to fix the other issues, but I hope this helps

This PR complies with the DCO; https://developercertificate.org/