### PR TITLE
fixed iPhone/iPad server setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -3023,7 +3023,7 @@ first install one of the following:
 and then copypaste the following command into `a-Shell`:
 
 ```sh
-curl https://github.com/9001/copyparty/raw/refs/heads/hovudstraum/contrib/setup-ashell.sh | sh
+curl https://raw.githubusercontent.com/9001/copyparty/refs/heads/hovudstraum/contrib/setup-ashell.sh | sh
 ```
 
 what this does:

--- a/contrib/README.md
+++ b/contrib/README.md
@@ -53,6 +53,13 @@
 ### [`zfs-tune.py`](zfs-tune.py)
 * optimizes databases for optimal performance when stored on a zfs filesystem; also see [openzfs docs](https://openzfs.github.io/openzfs-docs/Performance%20and%20Tuning/Workload%20Tuning.html#database-workloads) and specifically the SQLite subsection
 
+### [`setup-ashell.sh`](setup-ashell.sh)
+* downloads `copyparty-sfx.py` on $HOME/Documents on your iPhone/iPad
+* creates a simple config file on $HOME/Documents/cpc (can be edited with vim) (good luck closing it tho)
+* makes a simple executable script that starts the server. by default it opens the ports 80, 443 and 3923 for http and https. when run it will also print a qr code to access the server.
+* run with `cpp`
+* because of platform limitations it will only work if a-shell is running in the foreground
+
 # OS integration
 init-scripts to start copyparty as a service
 * [`systemd/copyparty.service`](systemd/copyparty.service) runs the sfx normally

--- a/contrib/setup-ashell.sh
+++ b/contrib/setup-ashell.sh
@@ -6,7 +6,7 @@
 #   https://apps.apple.com/us/app/a-shell/id1473805438
 #
 # step 2: copypaste the following command into a-Shell:
-#   curl https://github.com/9001/copyparty/raw/refs/heads/hovudstraum/contrib/setup-ashell.sh
+#	curl https://raw.githubusercontent.com/9001/copyparty/refs/heads/hovudstraum/contrib/setup-ashell.sh | sh
 #
 # step 3: launch copyparty with this command: cpp
 #


### PR DESCRIPTION
Fixed link for downloading the a-shell setup script on iPhone/iPad and added an entry in contrib/README.md for it

To show that your contribution is compatible with the MIT License, please include the following text somewhere in this PR description:  
This PR complies with the DCO; https://developercertificate.org/  
