### PR TITLE
Working basic example of authentik auth integration with copy party

### DIFF
--- a/docs/examples/docker/idp-authentik-traefik/README.md
+++ b/docs/examples/docker/idp-authentik-traefik/README.md
@@ -1,8 +1,7 @@
 > [!WARNING]  
 > I am unable to guarantee the quality, safety, and security of anything in this folder; it is a combination of examples I found online. Please submit corrections or improvements 🙏
 
-> [!WARNING]  
-> does not work yet... if you are able to fix this, please do!
+This example should be enough to get things working. I have confirmed this basic config personally. User creation and management work, however once a user is passed through to copy party, manual editing of the config file will be needed to control new users. i.e. anyone you let through your SSO portal will be granted basic/default settings and permissions, unless manually configured otherwise. 
 
 this is based on:
 * https://goauthentik.io/docker-compose.yml

--- a/docs/examples/docker/idp-authentik-traefik/README.md
+++ b/docs/examples/docker/idp-authentik-traefik/README.md
@@ -3,9 +3,24 @@
 
 This example should be enough to get things working. I have confirmed this basic config personally. User creation and management work, however once a user is passed through to copy party, manual editing of the config file will be needed to control new users. i.e. anyone you let through your SSO portal will be granted basic/default settings and permissions, unless manually configured otherwise. 
 
+To control more than just letting users through to your instance, make sure to add the username passed through by authentik to copyparty (default just the authentik username) with a plain password. e.g. :
+
+```
+[accounts]
+ username: foo
+```
+
+This will allow you to use copyparty's existing config mechanisms to manage users from your SSO. Add the relevant user/s to the su group to given them superuser privilleges within copyparty.
+
+Ensure to create the external network proxy (not needed if everything you want behind traefik is is the same docker-compose stack).To create the "proxy" docker network see https://docs.docker.com/reference/cli/docker/network/create/
+
+for an basic example:
+ `docker network create -d bridge proxy`
+
 this is based on:
 * https://goauthentik.io/docker-compose.yml
 * https://goauthentik.io/docs/providers/proxy/server_traefik
 
 incomplete list of modifications made:
 * support for running with podman as root on fedora (`:z` volumes, `label:disable`)
+v

--- a/docs/examples/docker/idp-authentik-traefik/README.md
+++ b/docs/examples/docker/idp-authentik-traefik/README.md
@@ -12,9 +12,9 @@ To control more than just letting users through to your instance, make sure to a
 
 This will allow you to use copyparty's existing config mechanisms to manage users from your SSO. Add the relevant user/s to the su group to given them superuser privilleges within copyparty.
 
-Ensure to create the external network proxy (not needed if everything you want behind traefik is is the same docker-compose stack).To create the "proxy" docker network see https://docs.docker.com/reference/cli/docker/network/create/
+Make sure to create the external network `proxy` (not needed if everything you want behind traefik is is the same docker-compose stack).To create the `proxy` docker network see https://docs.docker.com/reference/cli/docker/network/create/
 
-for an basic example:
+for a basic example:
  `docker network create -d bridge proxy`
 
 this is based on:

--- a/docs/examples/docker/idp-authentik-traefik/cpp/copyparty.conf
+++ b/docs/examples/docker/idp-authentik-traefik/cpp/copyparty.conf
@@ -20,12 +20,17 @@
   e2ts   # enable multimedia indexing
   ansi   # enable colors in log messages
 
+  # if we are confident that we got the docker-network config correct
+  # (meaning copyparty is only accessible through traefik, and
+  #  traefik makes sure that all requests go through authelia),
+  # then accept X-Forwarded-For and IdP headers from any private IP:
+  xff-src: lan
+  
   # enable IdP support by expecting username/groupname in
   # http-headers provided by the reverse-proxy; header "X-IdP-User"
   # will contain the username, "X-IdP-Group" the groupname
-  idp-h-usr: x-idp-user
-  idp-h-grp: x-idp-group
-
+  idp-h-usr: X-authentik-username
+  idp-h-grp: X-authentik-groups
 
 [/]      # create a volume at "/" (the webroot), which will
   /w     # share /w (the docker data volume, which is mapped to /srv/pub on the host in docker-compose.yml)

--- a/docs/examples/docker/idp-authentik-traefik/cpp/copyparty.conf
+++ b/docs/examples/docker/idp-authentik-traefik/cpp/copyparty.conf
@@ -13,7 +13,12 @@
 # because that is the data-volume in the docker containers,
 # because a deployment like this (with an IdP) is more commonly
 # seen in containerized environments -- but this is not required
+[accounts]
+  #match the username to authentik header used, password is ignored
+  username: foo
 
+[groups]
+  su: username  # "su" is a special group-name in copyparty, members get admin rights
 
 [global]
   e2dsa  # enable file indexing and filesystem scanning
@@ -52,26 +57,9 @@
     rwmda: ${u}, @su  # read-write-move-delete-admin for that username + the "su" group
 
 
-[/lounge/${g}]    # each group gets their own shared volume
-  /w/lounge/${g}  # stored at DATAVOLUME/lounge/groupname
-  accs:
-    r: *               # read-access for anyone, and
-    rwmda: @${g}, @su  # read-write-move-delete-admin for that group + the "su" group
-
-
-[/lounge/${g}/priv]    # and a private area for each group too
-  /w/lounge/${g}/priv  # stored at DATAVOLUME/lounge/groupname/priv
-  accs:
-    rwmda: @${g}, @su  # read-write-move-delete-admin for that group + the "su" group
-
-
 # and create some strategic volumes to prevent anyone from gaining
 # unintended access to priv folders if the users/groups db is lost
 [/u]
   /w/u
-  accs:
-    rwmda: @su
-[/lounge]
-  /w/lounge
   accs:
     rwmda: @su

--- a/docs/examples/docker/idp-authentik-traefik/docker-compose.yml
+++ b/docs/examples/docker/idp-authentik-traefik/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       - 'traefik.enable=true'
       - 'traefik.http.routers.fs.rule=Host(`fs.example.com`)'
       - 'traefik.http.routers.fs.entrypoints=http'
-      #- 'traefik.http.routers.fs.middlewares=authelia@docker'  # TODO: ???
+      - 'traefik.http.routers.fs.middlewares=ak-forwardauth@docker' # using authentik built-in docker outpost
     stop_grace_period: 15s  # thumbnailer is allowed to continue finishing up for 10s after the shutdown signal
     environment:
       LD_PRELOAD: /usr/lib/libmimalloc-secure.so.NOPE
@@ -29,9 +29,11 @@ services:
 
       PYTHONUNBUFFERED: 1
       # ensures log-messages are not delayed (but can reduce speed a tiny bit)
+    networks:
+      - proxy
 
   traefik:
-    image: traefik:v2.11
+    image: traefik:latest
     container_name: traefik
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock  # WARNING: this gives traefik full root-access to the host OS, but is recommended/required(?) by traefik
@@ -44,6 +46,12 @@ services:
       - '--providers.docker=true'
       - '--providers.docker.exposedByDefault=false'
       - '--entrypoints.web.address=:80'
+    labels:
+      - "traefik.enable=true"
+      #To allow for custom headers to be forwarded
+      - "traefik.http.middlewares.sslheader.headers.customrequestheaders.X-Forwarded-Proto=https"
+    networks:
+      - proxy
 
   postgresql:
     image: docker.io/library/postgres:12-alpine
@@ -63,6 +71,8 @@ services:
       POSTGRES_DB: authentik
     env_file:
       - .env
+    networks:
+      - authentik-backend
 
   redis:
     image: docker.io/library/redis:alpine
@@ -77,6 +87,8 @@ services:
       timeout: 3s
     volumes:
       - redis:/data:z
+    networks:
+      - authentik-backend
 
   authentik_server:
     image: ghcr.io/goauthentik/server:2024.2.1
@@ -100,6 +112,30 @@ services:
     depends_on:
       - postgresql
       - redis
+    labels:
+    # Https setup with Cloudflare as DNS provider for certresolver
+      - "traefik.enable=true"
+      - "traefik.http.routers.authentik.entrypoints=http"
+      - "traefik.http.routers.authentik.rule=Host(`auth.example.com`)"
+      - "traefik.http.middlewares.authentik-https-redirect.redirectscheme.scheme=https"
+      - "traefik.http.routers.authentik.middlewares=authentik-https-redirect"
+      - "traefik.http.routers.authentik-secure.entrypoints=https"
+
+      - "traefik.http.routers.authentik-secure.rule=Host(`auth.example.com`)"
+      - "traefik.http.routers.authentik-secure.tls=true"
+      - "traefik.http.routers.authentik-secure.tls.certresolver=cloudflare"
+      - "traefik.http.routers.authentik-secure.service=authentik"
+      - "traefik.http.services.authentik.loadbalancer.server.port=9000"
+      - "traefik.docker.network=proxy"
+
+      # ForwardAuth middleware → embedded outpost (internal URL!) will work for all services on the same docker network
+      - "traefik.http.middlewares.ak-forwardauth.forwardauth.address=http://authentik-server:9000/outpost.goauthentik.io/auth/traefik"
+      - "traefik.http.middlewares.ak-forwardauth.forwardauth.trustForwardHeader=true"
+      # Choose which headers you want forwarded to the backend
+      - "traefik.http.middlewares.ak-forwardauth.forwardauth.authResponseHeaders=X-authentik-username,X-authentik-groups,X-authentik-entitlements,X-authentik-email,X-authentik-name,X-authentik-uid"
+    networks:
+      - proxy
+      - authentik-backend
 
   authentik_worker:
     image: ghcr.io/goauthentik/server:2024.2.1
@@ -129,3 +165,10 @@ services:
     depends_on:
       - postgresql
       - redis
+    networks:
+      - proxy
+      - authentik-backend
+networks:
+  proxy:
+    external: true
+  authentik-backend:

--- a/docs/examples/docker/idp-authentik-traefik/docker-compose.yml
+++ b/docs/examples/docker/idp-authentik-traefik/docker-compose.yml
@@ -18,10 +18,23 @@ services:
     ports:
       - 3923
     labels:
-      - 'traefik.enable=true'
-      - 'traefik.http.routers.fs.rule=Host(`fs.example.com`)'
-      - 'traefik.http.routers.fs.entrypoints=http'
+      - "traefik.enable=true"
+      - "traefik.http.routers.fs.entrypoints=http"
+      - "traefik.http.routers.fs.rule=Host(`fs.example.com`)"
+      - "traefik.http.middlewares.fs-https-redirect.redirectscheme.scheme=https"
+      - "traefik.http.routers.fs.middlewares=fs-https-redirect"
+      - "traefik.http.routers.fs-secure.entrypoints=https"
+
+      - "traefik.http.routers.fs-secure.rule=Host(`fs.example.com`)"
+      - "traefik.http.routers.fs-secure.tls=true"
+      - "traefik.http.routers.fs-secure.tls.certresolver=cloudflare"
+      - "traefik.http.routers.fs-secure.service=fs"
+      - "traefik.http.services.fs.loadbalancer.server.port=3923"
+      
       - 'traefik.http.routers.fs.middlewares=ak-forwardauth@docker' # using authentik built-in docker outpost
+      - "traefik.docker.network=proxy"
+    depends_on:
+      - authentik_server
     stop_grace_period: 15s  # thumbnailer is allowed to continue finishing up for 10s after the shutdown signal
     environment:
       LD_PRELOAD: /usr/lib/libmimalloc-secure.so.NOPE
@@ -107,6 +120,7 @@ services:
     env_file:
       - .env
     ports:
+    #can be commented out if you only want to access authentik via traefik
       - 9000
       - 9443
     depends_on:
@@ -131,8 +145,8 @@ services:
       # ForwardAuth middleware → embedded outpost (internal URL!) will work for all services on the same docker network
       - "traefik.http.middlewares.ak-forwardauth.forwardauth.address=http://authentik-server:9000/outpost.goauthentik.io/auth/traefik"
       - "traefik.http.middlewares.ak-forwardauth.forwardauth.trustForwardHeader=true"
-      # Choose which headers you want forwarded to the backend
-      - "traefik.http.middlewares.ak-forwardauth.forwardauth.authResponseHeaders=X-authentik-username,X-authentik-groups,X-authentik-entitlements,X-authentik-email,X-authentik-name,X-authentik-uid"
+      # Choose which headers you want forwarded to the backend from https://docs.goauthentik.io/add-secure-apps/providers/proxy/server_traefik/
+      - "traefik.http.middlewares.ak-forwardauth.forwardauth.authResponseHeaders=X-authentik-username,X-authentik-groups"
     networks:
       - proxy
       - authentik-backend
@@ -168,6 +182,8 @@ services:
     networks:
       - proxy
       - authentik-backend
+
+#you have to manually create this network before starting docker-compose
 networks:
   proxy:
     external: true


### PR DESCRIPTION
Updated authentik docker example with working example stacks and updated README to better explain how to get setup.  I did my best to make it a basic level of secure and simple. If it can be improved please mention how! 😁  The key was specifying the xff-src, and using the correct authentik default headers.



To show that your contribution is compatible with the MIT License, please include the following text somewhere in this PR description:  
This PR complies with the DCO; https://developercertificate.org/  
