### PR TITLE
Allow building current code with flake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ scripts/docker/*.err
 
 # nix build output link
 result
+result-*
 
 # IDEA config
 .idea/

--- a/contrib/package/nix/overlay.nix
+++ b/contrib/package/nix/overlay.nix
@@ -1,7 +1,27 @@
-final: prev: {
-  copyparty = final.python3.pkgs.callPackage ./copyparty {
-    ffmpeg = final.ffmpeg-full;
+final: prev:
+let
+  fullAttrs = {
+    withHashedPasswords = true;
+    withCertgen = true;
+    withThumbnails = true;
+    withFastThumbnails = true;
+    withMediaProcessing = true;
+    withBasicAudioMetadata = true;
+    withZeroMQ = true;
+    withFTP = true;
+    withFTPS = true;
+    withTFTP = true;
+    withSMB = true;
+    withMagic = true;
   };
+
+  call = attrs: final.python3.pkgs.callPackage ./copyparty ({ ffmpeg = final.ffmpeg-full; } // attrs);
+in
+{
+  copyparty = call { stable = true; };
+  copyparty-unstable = call { stable = false; };
+  copyparty-full = call (fullAttrs // { stable = true; });
+  copyparty-unstable-full = call (fullAttrs // { stable = false; });
 
   python3 = prev.python3.override {
     packageOverrides = pyFinal: pyPrev: {

--- a/flake.nix
+++ b/flake.nix
@@ -12,7 +12,8 @@
     }:
     {
       nixosModules.default = ./contrib/nixos/modules/copyparty.nix;
-      overlays.default = import ./contrib/package/nix/overlay.nix;
+      overlays.default = final: prev:
+        (import ./contrib/package/nix/overlay.nix final prev) // { copypartyFlake = self; };
     }
     // flake-utils.lib.eachDefaultSystem (
       system:
@@ -22,26 +23,26 @@
           config = {
             allowAliases = false;
           };
-          overlays = [ self.overlays.default ];
+          overlays = [
+            self.overlays.default
+          ];
         };
       in
       {
         # check that copyparty builds with all optionals turned on
-        checks.copyparty-full = self.packages.${system}.copyparty.override {
-          withHashedPasswords = true;
-          withCertgen = true;
-          withThumbnails = true;
-          withFastThumbnails = true;
-          withMediaProcessing = true;
-          withBasicAudioMetadata = true;
-          withZeroMQ = true;
-          withFTPS = true;
-          withSMB = true;
+        checks = {
+          inherit (pkgs)
+            copyparty-full
+            copyparty-unstable-full
+            ;
         };
 
         packages = {
           inherit (pkgs)
             copyparty
+            copyparty-full
+            copyparty-unstable
+            copyparty-unstable-full
             ;
           default = self.packages.${system}.copyparty;
         };


### PR DESCRIPTION
Previously, the flake could only build the pinned (release) version of copyparty. Now it can also build the code in the repo around it, with the exception of webdeps which it copies from the pinned version.

With these modifications the `--version` output of `copyparty-unstable` looks like:

```text
copyparty v1.19.14 "unstable" (2025-09-28)
  CPython v3.12.10 on Linux64  [GCC 14.2.1 20250322]
   sqlite 3.48.0*1 | jinja 3.1.6 | pyftpd 2.0.1 | tftp (None)
```

---

This PR complies with the DCO; https://developercertificate.org/  
