### PR TITLE
Add --name-url option

### DIFF
--- a/copyparty/__main__.py
+++ b/copyparty/__main__.py
@@ -1155,6 +1155,7 @@ def add_general(ap, nc, srvname):
     ap2.add_argument("--urlform", metavar="MODE", type=u, default="print,xm", help="how to handle url-form POSTs; see \033[33m--help-urlform\033[0m")
     ap2.add_argument("--wintitle", metavar="TXT", type=u, default="cpp @ $pub", help="server terminal title, for example [\033[32m$ip-10.1.2.\033[0m] or [\033[32m$ip-]")
     ap2.add_argument("--name", metavar="TXT", type=u, default=srvname, help="server name (displayed topleft in browser and in mDNS)")
+    ap2.add_argument("--name-url", metavar="TXT", type=u, help="URL for server name hyperlink (displayed topleft in browser)")
     ap2.add_argument("--mime", metavar="EXT=MIME", type=u, action="append", help="\033[34mREPEATABLE:\033[0m map file \033[33mEXT\033[0mension to \033[33mMIME\033[0mtype, for example [\033[32mjpg=image/jpeg\033[0m]")
     ap2.add_argument("--mimes", action="store_true", help="list default mimetype mapping and exit")
     ap2.add_argument("--rmagic", action="store_true", help="do expensive analysis to improve accuracy of returned mimetypes; will make file-downloads, rss, and webdav slower (volflag=rmagic)")

--- a/copyparty/httpcli.py
+++ b/copyparty/httpcli.py
@@ -6493,7 +6493,11 @@ class HttpCli(object):
 
         try:
             if not self.args.nih:
-                srv_info.append(self.args.name)
+                if self.args.name_url:
+                    url = html_escape(self.args.name_url, True, True)
+                    srv_info.append(f"<a href='{url}'>{self.args.name}</a>")
+                else:
+                    srv_info.append(self.args.name)
         except:
             self.log("#wow #whoa")
 

--- a/copyparty/web/browser.css
+++ b/copyparty/web/browser.css
@@ -887,6 +887,9 @@ html.y #path a:hover {
 #srv_info2 span {
 	color: var(--srv-1);
 }
+#srv_info2 a {
+	padding: 0;
+}
 #srv_info2 {
 	display: none;
 }


### PR DESCRIPTION
Turns the server name into a hyperlink to a spefified URL

Can link back to homepage with `--name-url="/"`, control pannel with `--name-url="/?h"`, or external sites with `--name-url="https://src.lu"`.

To show that your contribution is compatible with the MIT License, please include the following text somewhere in this PR description:  
This PR complies with the DCO; https://developercertificate.org/  
