### PR TITLE
nixos module - allow for setting only the user or group under which the service runs + some readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2466,6 +2466,10 @@ copyparty on NixOS is configured via `services.copyparty` options, for example:
 ```nix
 services.copyparty = {
   enable = true;
+  # the user to run the service as
+  user = "copyparty"; 
+  # the group to run the service as
+  group = "copyparty"; 
   # directly maps to values in the [global] section of the copyparty config.
   # see `copyparty --help` for available options
   settings = {
@@ -2488,6 +2492,12 @@ services.copyparty = {
     };
     # or do both in one go
     k.passwordFile = "/run/keys/copyparty/k_password";
+  };
+
+  # create a group
+  groups = {
+    # users "ed" and "k" are part of the group g1
+    g1 = [ "ed" "k" ];
   };
 
   # create a volume

--- a/contrib/nixos/modules/copyparty.nix
+++ b/contrib/nixos/modules/copyparty.nix
@@ -370,12 +370,16 @@ in
         ) cfg.volumes
       );
 
-      users.groups.copyparty = lib.mkIf (cfg.user == "copyparty" && cfg.group == "copyparty") { };
-      users.users.copyparty = lib.mkIf (cfg.user == "copyparty" && cfg.group == "copyparty") {
-        description = "Service user for copyparty";
-        group = "copyparty";
-        home = externalStateDir;
-        isSystemUser = true;
+      users.groups = lib.mkIf (cfg.group == "copyparty") {
+        copyparty = { };
+      };
+      users.users = lib.mkIf (cfg.user == "copyparty") {
+        copyparty = {
+          description = "Service user for copyparty";
+          group = cfg.group;
+          home = externalStateDir;
+          isSystemUser = true;
+        };
       };
       environment.systemPackages = lib.mkIf cfg.mkHashWrapper [
         (pkgs.writeShellScriptBin "copyparty-hash" ''
@@ -394,4 +398,3 @@ in
     }
   );
 }
-


### PR DESCRIPTION
Referring to #867 
Allows to run the service as "user", while keeping the default group as "copyparty".
This configuration is more consistent with available nixos options, so perhaps this can be relevant for eventual mainlining. 
FYI, this is my first ever PR. I used my branch as flake input and the new generation was successful, so I guess it should be fine. 
…

To show that your contribution is compatible with the MIT License, please include the following text somewhere in this PR description:  
This PR complies with the DCO; https://developercertificate.org/  
