### PR TITLE
fix: ftp append

### DIFF
--- a/copyparty/ftpd.py
+++ b/copyparty/ftpd.py
@@ -249,7 +249,8 @@ class FtpFs(AbstractedFS):
                 need_unlink = False
                 td = 0
 
-        if w and need_unlink:
+        # Don't unlink file for append mode
+        if w and need_unlink and "a" not in mode:
             if td >= -1 and td <= self.args.ftp_wt:
                 # within permitted timeframe; unlink and accept
                 do_it = True

--- a/copyparty/ftpd.py
+++ b/copyparty/ftpd.py
@@ -250,9 +250,9 @@ class FtpFs(AbstractedFS):
                 td = 0
 
         # Don't unlink file for append mode
-        if w and need_unlink and "a" not in mode:
+        if w and need_unlink:
             if td >= -1 and td <= self.args.ftp_wt:
-                # within permitted timeframe; unlink and accept
+                # within permitted timeframe; allow overwrite or resume
                 do_it = True
             elif self.args.no_del or self.args.ftp_no_ow:
                 # file too old, or overwrite not allowed; reject
@@ -269,7 +269,8 @@ class FtpFs(AbstractedFS):
             if not do_it:
                 raise FSE("File already exists")
 
-            wunlink(self.log, ap, VF_CAREFUL)
+            elif "a" not in mode:
+                wunlink(self.log, ap, VF_CAREFUL)
 
         ret = open(fsenc(ap), mode, self.args.iobuf)
         if w and "fperms" in vfs.flags:

--- a/copyparty/ftpd.py
+++ b/copyparty/ftpd.py
@@ -249,7 +249,6 @@ class FtpFs(AbstractedFS):
                 need_unlink = False
                 td = 0
 
-        # Don't unlink file for append mode
         if w and need_unlink:
             if td >= -1 and td <= self.args.ftp_wt:
                 # within permitted timeframe; allow overwrite or resume
@@ -269,6 +268,7 @@ class FtpFs(AbstractedFS):
             if not do_it:
                 raise FSE("File already exists")
 
+            # Don't unlink file for append mode
             elif "a" not in mode:
                 wunlink(self.log, ap, VF_CAREFUL)
 


### PR DESCRIPTION
When this is received:

`{time} {IP}   [USER] APPE b'\\\\?\\{file_location}' completed=1 bytes=1892120 seconds=0.172`

copyparty currently unlinks, and overwrites the existing file, meaning live updates to the file are not correctly appended.

copyparty only uses `ftp_STOR` with `mode=w` by default.
pyftpdlib's default APPE implementation calls [ftp_STOR(file, "a")] automatically.

This PR adds an `a` mode condition for the unlink handling to prevent this behavior, and allow appending data to the existing file.