### PR TITLE
Add the ability for on message hooks to see selected files

### DIFF
--- a/copyparty/httpcli.py
+++ b/copyparty/httpcli.py
@@ -2146,8 +2146,18 @@ class HttpCli(object):
                     try:
                         zb = unquote(buf.replace(b"+", b" "))
                         plain = zb.decode("utf-8", "replace")
-                        if buf.startswith(b"msg="):
-                            plain = plain[4:]
+                        _msg_data = plain.split("&")
+                        msg_data = {}
+                        for i in _msg_data:
+                            d = i.split("=")
+                            if d[0] in msg_data.keys():
+                                if type(msg_data[d[0]]) is list:
+                                    msg_data[d[0]].append("=".join(d[1:]))
+                                else:
+                                    msg_data[d[0]] = [msg_data[d[0]], "=".join(d[1:])]
+                            else:
+                                msg_data[d[0]] = "=".join(d[1:])
+                        if "msg" in msg_data.keys():
                             xm = self.vn.flags.get("xm")
                             if xm:
                                 xm_rsp = runhook(
@@ -2165,7 +2175,8 @@ class HttpCli(object):
                                     len(buf),
                                     self.ip,
                                     time.time(),
-                                    plain,
+                                    msg_data["msg"],
+                                    {"sel": [self.vn.canonical(i) for i in msg_data.get("sel", [])]}
                                 )
 
                         t = "urlform_dec %d @ %r\n  %r\n"

--- a/copyparty/util.py
+++ b/copyparty/util.py
@@ -3886,6 +3886,7 @@ def _runhook(
     ip: str,
     at: float,
     txt: str,
+    other: dict
 ) -> dict[str, Any]:
     ret = {"rc": 0}
     areq, chk, imp, fork, sin, jtxt, wait, sp_ka, acmd = _parsehook(log, cmd)
@@ -3910,6 +3911,7 @@ def _runhook(
             "src": src,
             "txt": txt,
         }
+        ja.update(other)
         if imp:
             ja["log"] = log
             mod = loadpy(acmd[0], False)
@@ -3980,6 +3982,7 @@ def runhook(
     ip: str,
     at: float,
     txt: str,
+    other: dict,
 ) -> dict[str, Any]:
     assert broker or up2k  # !rm
     args = (broker or up2k).args  # type: ignore
@@ -3989,7 +3992,7 @@ def runhook(
     for cmd in cmds:
         try:
             hr = _runhook(
-                log, verbose, src, cmd, ap, vp, host, uname, perms, mt, sz, ip, at, txt
+                log, verbose, src, cmd, ap, vp, host, uname, perms, mt, sz, ip, at, txt, other
             )
             if verbose and log:
                 log("hook(%s) %r => \033[32m%s" % (src, cmd, hr), 6)

--- a/copyparty/util.py
+++ b/copyparty/util.py
@@ -3886,7 +3886,7 @@ def _runhook(
     ip: str,
     at: float,
     txt: str,
-    other: dict
+    other: dict = {},
 ) -> dict[str, Any]:
     ret = {"rc": 0}
     areq, chk, imp, fork, sin, jtxt, wait, sp_ka, acmd = _parsehook(log, cmd)
@@ -3982,7 +3982,7 @@ def runhook(
     ip: str,
     at: float,
     txt: str,
-    other: dict,
+    other: dict = {},
 ) -> dict[str, Any]:
     assert broker or up2k  # !rm
     args = (broker or up2k).args  # type: ignore

--- a/copyparty/web/browser.js
+++ b/copyparty/web/browser.js
@@ -8622,8 +8622,12 @@ var msel = (function () {
 		xhr.setRequestHeader('Content-Type', ct);
 		if (xhr.overrideMimeType)
 			xhr.overrideMimeType('Content-Type', ct);
+        let selected = msel.getsel()
+        for (let i=0;i<selected.length;i++) {
+            selected[i] = selected[i].vp;
+        }
 
-		xhr.send('msg=' + uricom_enc(xhr.msg));
+		xhr.send('msg=' + uricom_enc(xhr.msg) + "&sel=" + selected.join("&sel="));
 		return false;
 	};
 


### PR DESCRIPTION
This PR complies with the DCO; https://developercertificate.org/  

This pull request makes the browser send another param `sel` to the server when sending a message. This param is parsed and passed to any `xm` hooks. This allows on_message hooks to see selected files. This also adds a param to runhook that allows code that runs hooks to pass arbitrary values into the hook.