### PR TITLE
[Esperanto TL] fix capitalization on filesize option

### DIFF
--- a/copyparty/web/tl/epo.js
+++ b/copyparty/web/tl/epo.js
@@ -1,5 +1,5 @@
 
-// Linioj finiĝantaj per //m estas nekontrolitaj maŝinaj tradukoj
+// Linioj, finiĝantaj per "//m", estas nekontrolitaj maŝinaj tradukoj
 
 Ls.epo = {
 	"tt": "Esperanto",
@@ -204,7 +204,7 @@ Ls.epo = {
 	"u_nav_b": '<a href="#" id="modal-ok">Dosierojn</a><a href="#" id="modal-ng">Unu dosierujo</a>',
 
 	"cl_opts": "ŝaltiloj",
-	"cl_hfsz": "Dosiergrando", //m
+	"cl_hfsz": "dosiergrando",
 	"cl_themes": "etoso",
 	"cl_langs": "lingvo",
 	"cl_ziptype": "elŝutado de dosieroj",


### PR DESCRIPTION
Okay, now that each translation's strings are in their own files, doing small updates and such should be much easier, right?

(this is a quick web-edit, I hope it didn't cause any damaging changes to formatting or something, because other projects tend to frown on that. I can do a proper edit, if necessary)

(P.S. also the machine-translated lines warning was edited a bit)

This PR complies with the DCO; https://developercertificate.org/  
