### PR TITLE
nixos: Only create and bind volumes without variables

### DIFF
--- a/contrib/nixos/modules/copyparty.nix
+++ b/contrib/nixos/modules/copyparty.nix
@@ -48,6 +48,8 @@ let
 
   accountsWithPlaceholders = mapAttrs (name: attrs: passwordPlaceholder name);
 
+  volumesWithoutVariables = filterAttrs (k: v: !(hasInfix "\${" v.path)) cfg.volumes;
+
   configStr = ''
     ${mkSection "global" cfg.settings}
     ${cfg.globalExtraConfig}
@@ -325,7 +327,7 @@ in
           BindPaths =
             (if cfg.settings ? hist then [ cfg.settings.hist ] else [ ])
             ++ [ externalStateDir ]
-            ++ (mapAttrsToList (k: v: v.path) cfg.volumes);
+            ++ (mapAttrsToList (k: v: v.path) volumesWithoutVariables);
           # ProtectSystem = "strict";
           # Note that unlike what 'ro' implies,
           # this actually makes it impossible to read anything in the root FS,
@@ -367,7 +369,7 @@ in
               mode = ":755";
             };
           }
-        ) cfg.volumes
+        ) volumesWithoutVariables
       );
 
       users.groups = lib.mkIf (cfg.group == "copyparty") {


### PR DESCRIPTION
copyparty allows one to define dynamic volumes using variables, for example: a `/u/${u}` storage with the path `/storage/u/${u}`.

However, doing that with the NixOS module results in errors as the modules tries to create and bind the folder `/storage/u/${u}`, which is not what is wanted.

This PR fixes that by filtering out the volumes that contain variables in their path (i.e. contains `${`) from folders creation and binding in the service.

For users that defines a parent volume (e.g. a `/u` volume with the `/storage/u` path), they do not have to do anything as:
- `/storage/u` is created from the module config and `/storage/u/${u}` can be created dynamically by copyparty
- `/storage/u` is bound in the service, so `/storage/u/${u}` can be accessed and written

<!--To show that your contribution is compatible with the MIT License, please include the following text somewhere in this PR description:  -->
This PR complies with the DCO; https://developercertificate.org/
