### PR TITLE
nixos: Use volume/global chmod-d for module directory creation

### DIFF
--- a/contrib/nixos/modules/copyparty.nix
+++ b/contrib/nixos/modules/copyparty.nix
@@ -364,7 +364,17 @@ in
               #: in front of things means it wont change it if the directory already exists.
               group = ":${cfg.group}";
               user = ":${cfg.user}";
-              mode = ":755";
+              mode = ":${
+                # Use volume permissions if set
+                if (value.flags ? chmod_d) then
+                  value.flags.chmod_d
+                # Else, use global permission if set
+                else if (cfg.settings ? chmod-d) then
+                  cfg.settings.chmod-d
+                # Else, use the default permission
+                else
+                  "755"
+              }";
             };
           }
         ) cfg.volumes


### PR DESCRIPTION
Currently, the NixOS module automatically creates all the volumes' directories and sets their permissions to `755`.

This PR makes changes the permissions that is set to take into account the volume and/or global settings:
- If the volume's `chmod_d` setting is specified, use this for the mode
- Else, if the global `chmod-d` setting is specified, use this for the mode
- Else, use the previous default value of `755`

In all cases, the `:` prefix is used, so the tmpfile rule will not change the mode if the directory already exists (which follows the behaviour of `chmod-d` and `chmod_d` which only apply for new directories).

<!-- To show that your contribution is compatible with the MIT License, please include the following text somewhere in this PR description:  -->
This PR complies with the DCO; https://developercertificate.org/  
