### PR TITLE
Fix sb_lg not changing when changing dirs

### DIFF
--- a/copyparty/web/browser.js
+++ b/copyparty/web/browser.js
@@ -7194,6 +7194,7 @@ var treectl = (function () {
 
 		var lg0 = res.logues ? res.logues[0] || "" : "",
 			lg1 = res.logues ? res.logues[1] || "" : "",
+			sb_lg = res.sb_lg || "",
 			mds = res.readmes && treectl.ireadme,
 			md0 = mds ? res.readmes[0] || "" : "",
 			md1 = mds ? res.readmes[1] || "" : "",


### PR DESCRIPTION
To show that your contribution is compatible with the MIT License, please include the following text somewhere in this PR description:  
This PR complies with the DCO; https://developercertificate.org/  

This pull request sets the sb_lg every time the dir changes so that if you go into a unsandboxed dir from a sandboxed dir (or vise versa) the logues with become sandboxed/unsandboxed