### PR TITLE
Fix broken links in the control panel

### DIFF
--- a/copyparty/web/splash.html
+++ b/copyparty/web/splash.html
@@ -42,7 +42,7 @@
 				<thead><tr><th>%</th><th>speed</th><th>eta</th><th>idle</th><th>dir</th><th>file</th></tr></thead>
 				<tbody>
 					{%- for u in ups %}
-					<tr><td>{{ u[0] }}</td><td>{{ u[1] }}</td><td>{{ u[2] }}</td><td>{{ u[3] }}</td><td><a href="{{ u[4] }}">{{ u[5]|e }}</a></td><td>{{ u[6]|e }}</td></tr>
+					<tr><td>{{ u[0] }}</td><td>{{ u[1] }}</td><td>{{ u[2] }}</td><td>{{ u[3] }}</td><td><a href="{{ r }}/{{ u[4] }}">{{ u[5]|e }}</a></td><td>{{ u[6]|e }}</td></tr>
 					{%- endfor %}
 				</tbody>
 			</table>
@@ -54,7 +54,7 @@
 				<thead><tr><th>%</th><th>sent</th><th>speed</th><th>eta</th><th>idle</th><th></th><th>dir</th><th>file</th></tr></thead>
 				<tbody>
 					{%- for u in dls %}
-					<tr><td>{{ u[0] }}</td><td>{{ u[1] }}</td><td>{{ u[2] }}</td><td>{{ u[3] }}</td><td>{{ u[4] }}</td><td>{{ u[5] }}</td><td><a href="{{ u[6] }}">{{ u[7]|e }}</a></td><td>{{ u[8] }}</td></tr>
+					<tr><td>{{ u[0] }}</td><td>{{ u[1] }}</td><td>{{ u[2] }}</td><td>{{ u[3] }}</td><td>{{ u[4] }}</td><td>{{ u[5] }}</td><td><a href="{{ r }}/{{ u[6] }}">{{ u[7]|e }}</a></td><td>{{ u[8] }}</td></tr>
 					{%- endfor %}
 				</tbody>
 			</table>


### PR DESCRIPTION
While checking `my.copyparty.host/some-subdir/?h` control panel, I noticed an active upload, yet was still to realize that the upload directory link is relative to that `some-subdir`. When I clicked the link, all I got was a 404 error.

This PR fixes active download/upload links in the control panel.

This PR complies with the DCO; https://developercertificate.org/  
