### PR TITLE
fix: front-end validation for password field length

### DIFF
--- a/copyparty/web/splash.html
+++ b/copyparty/web/splash.html
@@ -111,7 +111,7 @@
 		<div>
 			<form id="lf" method="post" enctype="multipart/form-data" action="{{ r }}/{{ qvpath }}">
 				<input type="hidden" id="la" name="act" value="login" />
-				<input type="password" id="lp" name="cppwd" placeholder=" password" maxlength="64" />
+				<input type="password" id="lp" name="cppwd" placeholder=" password" oninput="this.setCustomValidity('')" oninvalid="this.setCustomValidity('Password must be between 1 and 64 characters')" "pattern="^.{1,64}$" />
 				<input type="hidden" name="uhash" id="uhash" value="x" />
 				<input type="submit" id="ls" value="Unlock" />
 				{%- if ahttps %}
@@ -137,9 +137,9 @@
 				<input type="hidden" id="la" name="act" value="login" />
 				{%- if this.args.usernames %}
 				<input type="text" id="lu" name="uname" placeholder=" username" size="12" />
-				<input type="password" id="lp" name="cppwd" placeholder=" password" size="12" maxlength="64" />
+				<input type="password" id="lp" name="cppwd" placeholder=" password" size="12" oninput="this.setCustomValidity('')" oninvalid="this.setCustomValidity('Password must be between 1 and 64 characters')" pattern="^.{1,64}$" />
 				{%- else %}
-				<input type="password" id="lp" name="cppwd" placeholder=" password" maxlength="64" />
+				<input type="password" id="lp" name="cppwd" placeholder=" password" oninput="this.setCustomValidity('')" oninvalid="this.setCustomValidity('Password must be between 1 and 64 characters')" pattern="^.{1,64}$" />
 				{%- endif %}
 				<input type="hidden" name="uhash" id="uhash" value="x" />
 				<input type="submit" id="ls" value="login" />

--- a/copyparty/web/splash.html
+++ b/copyparty/web/splash.html
@@ -111,7 +111,7 @@
 		<div>
 			<form id="lf" method="post" enctype="multipart/form-data" action="{{ r }}/{{ qvpath }}">
 				<input type="hidden" id="la" name="act" value="login" />
-				<input type="password" id="lp" name="cppwd" placeholder=" password" oninput="this.setCustomValidity('')" oninvalid="this.setCustomValidity('Password must be between 1 and 64 characters')" "pattern="^.{1,64}$" />
+				<input type="password" id="lp" name="cppwd" placeholder=" password" oninput="this.setCustomValidity('')" oninvalid="this.setCustomValidity('Password must be between 1 and 64 characters')" pattern="^.{1,64}$" />
 				<input type="hidden" name="uhash" id="uhash" value="x" />
 				<input type="submit" id="ls" value="Unlock" />
 				{%- if ahttps %}

--- a/copyparty/web/splash.html
+++ b/copyparty/web/splash.html
@@ -111,7 +111,7 @@
 		<div>
 			<form id="lf" method="post" enctype="multipart/form-data" action="{{ r }}/{{ qvpath }}">
 				<input type="hidden" id="la" name="act" value="login" />
-				<input type="password" id="lp" name="cppwd" placeholder=" password" />
+				<input type="password" id="lp" name="cppwd" placeholder=" password" maxlength="64" />
 				<input type="hidden" name="uhash" id="uhash" value="x" />
 				<input type="submit" id="ls" value="Unlock" />
 				{%- if ahttps %}
@@ -137,9 +137,9 @@
 				<input type="hidden" id="la" name="act" value="login" />
 				{%- if this.args.usernames %}
 				<input type="text" id="lu" name="uname" placeholder=" username" size="12" />
-				<input type="password" id="lp" name="cppwd" placeholder=" password" size="12" />
+				<input type="password" id="lp" name="cppwd" placeholder=" password" size="12" maxlength="64" />
 				{%- else %}
-				<input type="password" id="lp" name="cppwd" placeholder=" password" />
+				<input type="password" id="lp" name="cppwd" placeholder=" password" maxlength="64" />
 				{%- endif %}
 				<input type="hidden" name="uhash" id="uhash" value="x" />
 				<input type="submit" id="ls" value="login" />


### PR DESCRIPTION
Adds max length validation to password field, since its limited by 64 chars in backend.

Considered maxlength, but this shows more a useful validation error instead of truncating the field.

This PR complies with the DCO; https://developercertificate.org/  