### PR TITLE
fix typo / access permissions in copyparty.conf

### DIFF
--- a/docs/examples/docker/idp/copyparty.conf
+++ b/docs/examples/docker/idp/copyparty.conf
@@ -50,7 +50,7 @@
 [/]      # create a volume at "/" (the webroot), which will
   /w     # share /w (the docker data volume)
   accs:
-    rw: *       # everyone gets read-access, but
+    r: *       # everyone gets read-access, but
     rwmda: @su  # the group "su" gets read-write-move-delete-admin
 
 


### PR DESCRIPTION
Removed write permissions from root volume.

To show that your contribution is compatible with the MIT License, please include the following text somewhere in this PR description:  
This PR complies with the DCO; https://developercertificate.org/  
