### PR TITLE
fix: round bad floating point arithmetic

### DIFF
--- a/copyparty/web/browser.js
+++ b/copyparty/web/browser.js
@@ -2449,7 +2449,7 @@ function mpause(e) {
 				return true;
 
 			dist *= -1;
-			mp.setvol(mp.vol + dist / 500);
+			mp.setvol(Math.round((mp.vol + dist / 500) * 100) / 100 );
 			vbar.draw();
 			ev(e);
 		};


### PR DESCRIPTION
when using the scroll wheel on the volume bar, it adjusts in factors of 2, except when going from 92 -> 89, due to bad floating point arithmetic (0.94 - 0.02 is calculated as 91.9...9)


https://github.com/user-attachments/assets/d0d09634-14ba-4e86-b473-0eff513756c7

This PR complies with the DCO; https://developercertificate.org/  
