### PR TITLE
Parse total space from `vmaxb` volflag

### DIFF
--- a/copyparty/httpcli.py
+++ b/copyparty/httpcli.py
@@ -117,7 +117,6 @@ from .util import (
     undot,
     unescape_cookie,
     unquotep,
-    unhumanize,
     vjoin,
     vol_san,
     vroots,
@@ -1832,18 +1831,16 @@ class HttpCli(object):
             or (zi == 4 and self.can_write and self.can_read)
             or (zi == 3 and self.can_admin)
         ):
-            vmaxb_value = unhumanize(vn.flags.get("vmaxb") or "0")
-            if vmaxb_value:
-                try:
-                    bused, _ = self.conn.hsrv.broker.ask("up2k.get_volsizes", [vn.realpath]).get()[0]
-                    bfree = max(0, vmaxb_value - bused)
-                    btot = vmaxb_value
-                except:
-                    bfree, btot, _ = get_df(vn.realpath, False)
-            else:
-                bfree, btot, _ = get_df(vn.realpath, False)
-            
+            bfree, btot, _ = get_df(vn.realpath, False)
             if btot:
+                if "vmaxb" in vn.flags:
+                    try:
+                        zi, _ = self.conn.hsrv.broker.ask(
+                            "up2k.get_volsizes", [vn.realpath]
+                        ).get()[0]
+                        bfree = min(bfree, max(0, vn.lim.vbmax - zi))
+                    except:
+                        pass
                 df = {
                     "quota-available-bytes": str(bfree),
                     "quota-used-bytes": str(btot - bfree),

--- a/copyparty/httpcli.py
+++ b/copyparty/httpcli.py
@@ -117,6 +117,7 @@ from .util import (
     undot,
     unescape_cookie,
     unquotep,
+    unhumanize,
     vjoin,
     vol_san,
     vroots,
@@ -1831,7 +1832,17 @@ class HttpCli(object):
             or (zi == 4 and self.can_write and self.can_read)
             or (zi == 3 and self.can_admin)
         ):
-            bfree, btot, _ = get_df(vn.realpath, False)
+            vmaxb_value = unhumanize(vn.flags.get("vmaxb") or "0")
+            if vmaxb_value:
+                try:
+                    bused, _ = self.conn.hsrv.broker.ask("up2k.get_volsizes", [vn.realpath]).get()[0]
+                    bfree = max(0, vmaxb_value - bused)
+                    btot = vmaxb_value
+                except:
+                    bfree, btot, _ = get_df(vn.realpath, False)
+            else:
+                bfree, btot, _ = get_df(vn.realpath, False)
+            
             if btot:
                 df = {
                     "quota-available-bytes": str(bfree),


### PR DESCRIPTION
Added a couple lines to return the total space available in a volume based on the `vmaxb` volflag, and change how the used/free space is calculated when using that.

Example:
I have a ~600GB HDD. I have created 3 volumes, dir1, dir2, dir3.
Dir1 has **100GB** `vmaxb` volflag, Dir2 has **50GB** `vmaxb` volflag, and Dir3 has no `vmaxb` volflag set.

Without the changes of this PR (this is how currently works) (sorry for the spanish language) my drives look like this:

<img width="521" height="117" alt="unlimited" src="https://github.com/user-attachments/assets/4ef76ce7-ee28-424f-ad20-1752d6eca6a2" />

With the changes of this PR, you can see windows shows correctly the quota:

<img width="522" height="117" alt="limited" src="https://github.com/user-attachments/assets/46b85f8e-2048-4639-971e-a175b98ea8d2" />

I have not tested it a lot, just manually with some volumes I have configured in the pictures, but I can try to add some unit tests if you want (although I might need some help with that...)

====

<details>
<summary>disclaimer after reading `contributing.md` (click to expand)</summary>
I used an AI to ask it 2 things:

1) where was the code that returned the total space available and the total space used in order to insert these changes

2) help to calculate the space used on the volume (to be precise, the method call `self.conn.hsrv.broker.ask("up2k.get_volsizes", [vn.realpath]).get()[0]` from line 1838)

I did this because I just wanted to see if I could implement it but I didn't want to invest a lot of time as I have other projects that require my attention (but my ADHD brain wouldn't let me sleep over having the network drives with the wrong available/used space values...)

I've set this disclaimer because as I was opening this PR i saw the note in the contributing guidelines to not use AI, and I'm truly sorry as I was not aware of this when I was doing the changes.

I will understand if you decide to decline the pull request, and i will not get angry/annoyed at the decision. You've made a truly great software and if you decide to keep it fully organic with no AI at all then I am not going to complain.
</details>

====

I think this PR complies with the DCO anyways (or I hope it still does); https://developercertificate.org/  