### PR TITLE
docs: example of using `--idp-login`/`--idp-logout` with caddy and authelia

### DIFF
--- a/README.md
+++ b/README.md
@@ -2011,7 +2011,7 @@ you can disable the built-in password-based login system, and instead replace it
 
   * `--auth-ord` configured auth precedence, for example to allow overriding the IdP with a copyparty password
 
-* the login/logout links/buttons can be replaced with links to your IdP with `--idp-login` and `--idp-logout` , for example `--idp-login /idp/login/?redir={dst}` will expand `{dst}` to the page the user was on when clicking Login
+* the login/logout links/buttons can be replaced with links to your IdP (or your reverse proxy, that will route request to your IdP, [example](./docs/examples/docker/idp-authelia-caddy)) with `--idp-login` and `--idp-logout` , for example `--idp-login /idp/login/?redir={dst}` will expand `{dst}` to the page the user was on when clicking Login
 
 * if your IdP-server is slow, consider `--idp-cookie` and let requests with the cookie `cppws` bypass the IdP; experimental sessions-based feature added for a party
 

--- a/docs/examples/docker/idp-authelia-caddy/README.md
+++ b/docs/examples/docker/idp-authelia-caddy/README.md
@@ -1,0 +1,18 @@
+> [!WARNING]  
+> this is modified version of [idp-authelia-traefik](../idp-authelia-traefik/), similiar to what i use, all work is based on that example and my own developments, everything written in readme of idp-authelia-traefik applies here as well
+
+to try this out with minimal adjustments:
+* specify what filesystem-path to share with copyparty, replacing the default/example value `/srv/pub` in `docker-compose.yml`
+* add `127.0.0.1 fs.example.com traefik.example.com authelia.example.com` to your `/etc/hosts`
+* `sudo docker-compose up`
+* login to https://fs.example.com/ with username `authelia` password `authelia`
+
+# performance
+
+7840hs, nvme ssd and ubuntu 25.10
+
+| 1MB files D/L | https D/L |  http D/L  | approach |
+| -------------:| ---------:|:----------:| -------- |
+|  385 files/s  | 790 MiB/s | 1.7+ GiB/s | `copyparty/ac` port forwarding |
+|  294 files/s  | 750 MiB/s | n/a        | `copyparty/ac` behind caddy |
+|  108 files/s  | 750 MiB/s | n/a        | caddy and authelia **(you are here)** |

--- a/docs/examples/docker/idp-authelia-caddy/authelia/configuration.yml
+++ b/docs/examples/docker/idp-authelia-caddy/authelia/configuration.yml
@@ -1,0 +1,60 @@
+# Authelia configuration
+
+identity_validation:
+  reset_password:
+    jwt_secret: 'a_very_important_secret_so_please_change_this'
+
+server:
+  address: 'tcp://:9091'
+
+log:
+  level: info
+
+totp:
+  issuer: authelia.com
+
+authentication_backend:
+  file:
+    path: /config/users_database.yml
+
+access_control:
+  default_policy: deny
+  rules:
+    - domain: auth.example.com
+      policy: bypass  # Allow access to the login UI
+    - domain: fs.example.com
+      policy: bypass  # bypass here because we are allowing limited access without login
+
+session:
+  secret: unsecure_session_secret
+  cookies:
+    - name: authelia_session
+      domain: example.com  # this should match whatever your root protected domain is
+      default_redirection_url: https://fs.example.com
+      authelia_url: https://authelia.example.com/
+      expiration: 3600  # 1 hour
+      inactivity: 300  # 5 minutes
+
+  redis:
+    host: valkey
+    port: 6379
+    password: your_secure_password_here
+
+
+regulation:
+  max_retries: 3
+  find_time: 120
+  ban_time: 300
+
+storage:
+  encryption_key: you_must_generate_a_random_string_of_more_than_twenty_chars_and_configure_this
+  local:
+    path: /config/db.sqlite3
+
+notifier:
+  disable_startup_check: true
+  smtp:
+    address: 'smtp://127.0.0.1:25'
+    username: 'test'
+    password: 'password'
+    sender: "Authelia <admin@example.com>"

--- a/docs/examples/docker/idp-authelia-caddy/authelia/users_database.yml
+++ b/docs/examples/docker/idp-authelia-caddy/authelia/users_database.yml
@@ -1,0 +1,18 @@
+# based on https://github.com/authelia/authelia/blob/39763aaed24c4abdecd884b47357a052b235942d/examples/compose/lite/authelia/users_database.yml
+
+# Users Database
+
+# This file can be used if you do not have an LDAP set up.
+
+# List of users
+users:
+  authelia:
+    disabled: false
+    displayname: "Authelia User"
+    # Password is authelia
+    password: "$6$rounds=50000$BpLnfgDsc2WD8F2q$Zis.ixdg9s/UOJYrs56b5QEZFiZECu0qZVNsIYxBaNJ7ucIL.nlxVCT5tqh8KHG8X4tlwCFm5r6NTOZZ5qRFN/"
+    email: authelia@authelia.com
+    groups:
+      - admins
+      - dev
+      - su

--- a/docs/examples/docker/idp-authelia-caddy/caddy/Caddyfile
+++ b/docs/examples/docker/idp-authelia-caddy/caddy/Caddyfile
@@ -1,0 +1,29 @@
+fs.example.com {
+    tls internal # needed if you don't have an actual domain and use local dns in your network
+    forward_auth authelia:9091 {
+        uri /api/authz/forward-auth
+        copy_headers Remote-User Remote-Groups Remote-Email Remote-Name
+    }
+    
+    route {
+        @login query rd=*
+        redir @login https://authelia.example.com{uri}
+        
+        @logout path /logout
+        redir @logout https://authelia.example.com{uri}
+        
+        reverse_proxy copyparty:3923 {
+            header_up Cookie "authelia_session=[^;]+" "authelia_session=_"
+        }
+    }
+}
+
+# fs.example.com {
+#     tls internal # needed if you don't have an actual domain and use local dns in your network
+#     reverse_proxy copyparty:3923
+# }
+
+authelia.example.com {
+    tls internal # needed if you don't have an actual domain and use local dns in your network
+    reverse_proxy authelia:9091
+}

--- a/docs/examples/docker/idp-authelia-caddy/cpp/copyparty.conf
+++ b/docs/examples/docker/idp-authelia-caddy/cpp/copyparty.conf
@@ -1,0 +1,87 @@
+# not actually YAML but lets pretend:
+# -*- mode: yaml -*-
+# vim: ft=yaml:
+
+
+# example config for how authelia can be used to replace
+# copyparty's built-in authentication/authorization mechanism,
+# providing copyparty with HTTP headers through traefik to
+# signify who the user is, and what groups they belong to
+#
+# the filesystem-path that will be shared with copyparty is
+# specified in the docker-compose in the parent folder, where
+# a real filesystem-path is mapped onto this container's path `/w`,
+# meaning `/w` in this config-file is actually `/srv/pub` in the
+# outside world (assuming you didn't modify that value)
+
+
+[global]
+  e2dsa  # enable file indexing and filesystem scanning
+  e2ts   # enable multimedia indexing
+  ansi   # enable colors in log messages
+  #q      # disable logging for more performance
+
+  # if we are confident that we got the docker-network config correct
+  # (meaning copyparty is only accessible through traefik, and
+  #  traefik makes sure that all requests go through authelia),
+  # then accept X-Forwarded-For and IdP headers from any private IP:
+  xff-src: lan
+
+  # enable IdP support by expecting username/groupname in
+  # http-headers provided by the reverse-proxy; header "X-IdP-User"
+  # will contain the username, "X-IdP-Group" the groupname
+  idp-h-usr: remote-user
+  idp-h-grp: remote-groups
+
+  # replace login/logout buttons with links that will be routed by caddy
+  # {dst} will expand to the page user was on when clicking login
+  idp-login: /?rd=https://fs.example.com{dst}&rm=GET
+  idp-logout: /logout/?rd=https://fs.example.com/&rm=GET
+
+  # DEBUG: show all incoming request headers from traefik/authelia
+  #ihead: *
+
+
+[/]      # create a volume at "/" (the webroot), which will
+  /w     # share /w (the docker data volume, which is mapped to /srv/pub on the host in docker-compose.yml)
+  accs:
+    rw: *       # everyone gets read-access, but
+    rwmda: @su  # the group "su" gets read-write-move-delete-admin
+
+
+[/u/${u}]    # each user gets their own home-folder at /u/username
+  /w/u/${u}  # which will be "u/username" in the docker data volume
+  accs:
+    r: *              # read-access for anyone, and
+    rwmda: ${u}, @su  # read-write-move-delete-admin for that username + the "su" group
+
+
+[/u/${u}/priv]    # each user also gets a private area at /u/username/priv
+  /w/u/${u}/priv  # stored at DATAVOLUME/u/username/priv
+  accs:
+    rwmda: ${u}, @su  # read-write-move-delete-admin for that username + the "su" group
+
+
+[/lounge/${g}]    # each group gets their own shared volume
+  /w/lounge/${g}  # stored at DATAVOLUME/lounge/groupname
+  accs:
+    r: *               # read-access for anyone, and
+    rwmda: @${g}, @su  # read-write-move-delete-admin for that group + the "su" group
+
+
+[/lounge/${g}/priv]    # and a private area for each group too
+  /w/lounge/${g}/priv  # stored at DATAVOLUME/lounge/groupname/priv
+  accs:
+    rwmda: @${g}, @su  # read-write-move-delete-admin for that group + the "su" group
+
+
+# and create some strategic volumes to prevent anyone from gaining
+# unintended access to priv folders if the users/groups db is lost
+[/u]
+  /w/u
+  accs:
+    rwmda: @su
+[/lounge]
+  /w/lounge
+  accs:
+    rwmda: @su

--- a/docs/examples/docker/idp-authelia-caddy/docker-compose.yml
+++ b/docs/examples/docker/idp-authelia-caddy/docker-compose.yml
@@ -1,0 +1,63 @@
+---
+
+networks:
+  net:
+    driver: bridge
+
+services:
+  copyparty:
+    image: copyparty/ac:latest
+    container_name: idp_copyparty
+    user: "1000:1000"  # should match the user/group of your fileshare volumes
+    volumes:
+      - ./cpp/:/cfg:z  # the copyparty config folder
+      - /srv/pub:/w:z  # this is where we declare that "/srv/pub" is the filesystem-path on the server that shall be shared online
+    networks:
+      - net
+    expose:
+      - 3923
+    stop_grace_period: 15s  # thumbnailer is allowed to continue finishing up for 10s after the shutdown signal
+    environment:
+      LD_PRELOAD: /usr/lib/libmimalloc-secure.so.NOPE
+      # enable mimalloc by replacing "NOPE" with "2" for a nice speed-boost (will use twice as much ram)
+      PYTHONUNBUFFERED: 1
+      # ensures log-messages are not delayed (but can reduce speed a tiny bit)
+
+  authelia:
+    image: authelia/authelia:4.39.5@sha256:023e02e5203dfa0ebaee7a48b5bae34f393d1f9cada4a9df7fbf87eb1759c671
+    container_name: idp_authelia
+    volumes:
+      - ./authelia:/config:z
+    networks:
+      - net
+    expose:
+      - 9091
+    restart: unless-stopped
+    environment:
+      - TZ=Etc/UTC
+
+  valkey:
+    image: valkey/valkey:8.1.3-alpine3.22@sha256:0d27f0bca0249f61d060029a6aaf2e16b2c417d68d02a508e1dfb763fa2948b4
+    container_name: idp_valkey
+    volumes:
+      - ./valkey:/data:z
+    networks:
+      - net
+    expose:
+      - 6379
+    restart: unless-stopped
+    environment:
+      - TZ=Etc/UTC
+      - VALKEY_EXTRA_FLAGS=--requirepass your_secure_password_here
+
+  caddy:
+    image: caddy:2.10-alpine
+    container_name: idp_caddy
+    volumes:
+      - ./caddy/Caddyfile:/etc/caddy/Caddyfile
+    networks:
+      - net
+    ports:
+      - 443:443/tcp
+      - 443:443/udp
+    restart: unless-stopped


### PR DESCRIPTION
i added example of using copyparty in docker with caddy and authelia, utilizing `--idp-login`/`--idp-logout` options

This PR complies with the DCO; https://developercertificate.org/  
