### PR TITLE
Improve chpw UI

### DIFF
--- a/copyparty/httpcli.py
+++ b/copyparty/httpcli.py
@@ -5471,7 +5471,7 @@ class HttpCli(object):
             no304vis=self.args.no304 > 0,
             msg=BADXFFB if hasattr(self, "bad_xff") else "",
             ver=S_VERSION if show_ver else "",
-            chpw=self.args.chpw and self.uname != "*",
+            chpw=self.args.chpw and self.uname != "*" and self.uname not in self.args.chpw_no,
             ahttps="" if self.is_https else "https://" + self.host + self.req,
         )
         self.reply(html.encode("utf-8"))

--- a/copyparty/web/splash.html
+++ b/copyparty/web/splash.html
@@ -213,6 +213,7 @@ var SR="{{ r }}",
 	dfavico="{{ favico }}";
 
 var STG = window.localStorage;
+var chpw_min = {{ this.args.chpw_len }};
 document.documentElement.className = (STG && STG.cpp_thm) || "{{ this.args.theme }}";
 
 </script>

--- a/copyparty/web/splash.js
+++ b/copyparty/web/splash.js
@@ -5,6 +5,7 @@ Ls.eng = {
 		"lo2": "ends the session on all browsers",
 		"u2": "time since the last server write$N( upload / rename / ... )$N$N17d = 17 days$N1h23 = 1 hour 23 minutes$N4m56 = 4 minutes 56 seconds",
 		"v2": "use this server as a local HDD",
+		"tan": "ERROR: New password has to be at least $N characters",
 		"ta1": "fill in your new password first",
 		"ta2": "repeat to confirm new password:",
 		"ta3": "found a typo; please try again",
@@ -102,6 +103,9 @@ if (/\&re=/.test('' + location))
 		ev(e);
 		if (!pwi.value)
 			return ebi('lm').innerHTML = d.ta1;
+
+		if (ebi('lp').value.length < chpw_min)
+			return ebi('lm').innerHTML = d.tan.replace('$N', chpw_min);
 
 		modal.prompt(d.ta2, "y", mok, null, stars);
 	};


### PR DESCRIPTION
This improves the behavior of the password-change frontend:
- The "change password"-button is hidden when the user isn't allowed to change their password.
- The UI blocks the user from entering a password shorter than the minimum length _before_ confirming their password. (+1 translation token)

(This PR complies with the DCO; https://developercertificate.org/)
