### PR TITLE
Fix right-click menu

### DIFF
--- a/copyparty/web/browser.js
+++ b/copyparty/web/browser.js
@@ -9600,7 +9600,7 @@ var rcm = (function () {
 
 				selFile.path = basenames(file.children[1].firstChild.href).split('?')[0];
 				selFile.relpath = selFile.path.split('/').slice(-1)[0];
-				if (file.children[3].innerHTML == "---")
+				if (noq_href(file.children[1].firstChild).endsWith("/"))
 					selFile.type = "dir";
 				else {
 					var lead = file.firstChild.firstChild;


### PR DESCRIPTION
Fixes a crash involving the right-click menu when the file type isn't the fourth column of the file type.
(Very specific I know)

(Also, this PR complies with the DCO; https://developercertificate.org/)
