### PR TITLE
nixos: use mkPackageOption instead of mkOption for the package option

### DIFF
--- a/contrib/nixos/modules/copyparty.nix
+++ b/contrib/nixos/modules/copyparty.nix
@@ -69,11 +69,8 @@ in
   options.services.copyparty = {
     enable = mkEnableOption "web-based file manager";
 
-    package = mkOption {
-      type = types.package;
-      default = pkgs.copyparty;
-      defaultText = "pkgs.copyparty";
-      description = ''
+    package = mkPackageOption pkgs "copyparty" {
+      extraDescription = ''
         Package of the application to run, exposed for overriding purposes.
       '';
     };


### PR DESCRIPTION
This gets rid of a warning when trying to build a system with `documentation.nixos.includeAllModules` enabled
```log
warning: Attempt to evaluate package pkgs.copyparty.out in option documentation; this is not supported and will eventually be an error. Use `mkPackageOption{,MD}` or `literalExpression` instead.
```

To show that your contribution is compatible with the MIT License, please include the following text somewhere in this PR description:  
This PR complies with the DCO; https://developercertificate.org/  
