### PR TITLE
fix: update `utime_c` to accept float timestamps

### DIFF
--- a/copyparty/bos/bos.py
+++ b/copyparty/bos/bos.py
@@ -106,14 +106,14 @@ def utime(
 def utime_c(
     log: Union["NamedLogger", Any],
     p: str,
-    ts: int,
+    ts: float,
     follow_symlinks: bool = True,
     throw: bool = False,
-) -> Optional[int]:
+) -> Optional[float]:
     clamp = 0
     ov = ts
     bp = fsenc(p)
-    now = int(time.time())
+    now = time.time()
     while True:
         try:
             if SYMTIME:

--- a/copyparty/httpcli.py
+++ b/copyparty/httpcli.py
@@ -2618,7 +2618,7 @@ class HttpCli(object):
         at = mt = time.time() - lifetime
         cli_mt = self.headers.get("x-oc-mtime")
         if cli_mt:
-            bos.utime_c(self.log, path, int(cli_mt), False)
+            bos.utime_c(self.log, path, float(cli_mt), False)
 
         if nameless and "magic" in vfs.flags:
             try:

--- a/tests/test_webdav.py
+++ b/tests/test_webdav.py
@@ -63,6 +63,20 @@ Accept-Encoding: gzip
 fgsfds"""
 
 
+RCLONE_PUT_FLOAT = """PUT /%s HTTP/1.1
+Host: 127.0.0.1:3923
+User-Agent: rclone/v1.67.0
+Content-Length: 6
+Authorization: Basic azp1
+Content-Type: application/octet-stream
+Oc-Checksum: SHA1:f5e3dc3fb27af53cd0005a1184e2df06481199e8
+Referer: http://127.0.0.1:3923/
+X-Oc-Mtime: 1689453578.123
+Accept-Encoding: gzip
+
+fgsfds"""
+
+
 # tcpdump of `rclone delete dav:/a/d1/`  (it does propfind recursively and then this on each file)
 # (note: `rclone rmdirs dav:/a/d1/` does the same thing but just each folder after asserting they're empty)
 RCLONE_DELETE = """DELETE /%s HTTP/1.1
@@ -200,6 +214,11 @@ class TestHttpCli(TC):
         # then it uploads the file
         h, b = self.req(RCLONE_PUT % ("a/fa",))
         self.assertStart("HTTP/1.1 201 Created\r", h)
+
+        # float x-oc-mtime should be accepted
+        h, b = self.req(RCLONE_PUT_FLOAT % ("a/fb",))
+        self.assertStart("HTTP/1.1 201 Created\r", h)
+        self.assertAlmostEqual(os.path.getmtime("a/fb"), 1689453578.123, places=3)
 
         # then it does a propfind to confirm
         h, b = self.req(RCLONE_PROPFIND % ("a/fa",))


### PR DESCRIPTION
Some WebDAV clients (e.g., Tampermonkey sync) send `x-oc-mtime` as a decimal string. Copyparty previously used `int(...)`, which raises `ValueError` for decimal inputs. Python’s `os.utime` accepts float timestamps, so it’s safe to pass floats and preserve sub-second precision where supported.

I updated `bos.utime_c` to accept float timestamps, and added a test for when `x-oc-mtime` is in milliseconds, and parse the header as a float now.

However if you prefer simpler approach, you could also just change `int(cli_mt)` in `httpcli.py` to `int(float(cli_mt))` or `int(cli_mt.split('.')[0])` to truncate it. We could also try-catch to parse int first and fall back to float only on failure.

Let me know if you want any changes, or a different approach

Fixes #1239

This PR complies with the DCO; https://developercertificate.org/  
