### PR TITLE
Don't show right-click menu in file viewer; fixes #1280

### DIFF
--- a/copyparty/web/browser.js
+++ b/copyparty/web/browser.js
@@ -9753,7 +9753,7 @@ var rcm = (function () {
 	}
 
 	ebi('wrap').oncontextmenu = function(e) {
-		if (!r.enabled || e.shiftKey || (r.double && menu.style.display)) {
+		if (!r.enabled || e.shiftKey || (r.double && menu.style.display) || /doc=/.exec(location.search)) {
 			r.hide(true);
 			return true;
 		}


### PR DESCRIPTION
The right-click menu was still enabled in the text viewer (`?doc=`). Now it checks for that url and doesn't open the menu when it finds it.

(This PR complies with the DCO; https://developercertificate.org/) 
