### PR TITLE
add optional checking for vulnerable versions

### DIFF
--- a/contrib/systemd/copyparty.example.conf
+++ b/contrib/systemd/copyparty.example.conf
@@ -18,14 +18,14 @@
   # (note: enable compression by adding .xz at the end)
   q, lo: $LOGS_DIRECTORY/%Y-%m%d.log
 
-  # url to check against for vulnerable versions (default disabled); setting this will enable automatic 
-  # vulnerability checks. the notification, in case you are running a vulnerable version, is shown on the 
-  # admin panel (/?h) and only for users with admin permissions. you can choose between the value given here, 
-  # or alternatively use https://api.copyparty.eu/security-advisories, or your own custom endpoint
-  vc-url: https://api.github.com/repos/9001/copyparty/security-advisories
+  # enable version-checker by uncommenting one of the 'vc-url' lines below; this will
+  # periodically check if your copyparty version has a known security vulnerability,
+  # showing a warning on /?h (control-panel) for all users with permission 'a' or 'A'
+  #vc-url: https://api.github.com/repos/9001/copyparty/security-advisories?per_page=9
+  #vc-url: https://api.copyparty.eu/advisories
 
-  # how many seconds to wait between vulnerability checks; default is 86400 (= 1 day).
-  vc-interval: 86400
+  vc-age: 3  # how many hours to wait between each version-check
+  vc-exit  # emergency-exit if a version-check indicates that the current version is vulnerable
 
   # p: 80,443,3923   # listen on 80/443 as well (requires CAP_NET_BIND_SERVICE)
   # i: 127.0.0.1     # only allow connections from localhost (reverse-proxies)

--- a/contrib/systemd/copyparty.example.conf
+++ b/contrib/systemd/copyparty.example.conf
@@ -18,6 +18,15 @@
   # (note: enable compression by adding .xz at the end)
   q, lo: $LOGS_DIRECTORY/%Y-%m%d.log
 
+  # url to check against for vulnerable versions (default disabled); setting this will enable automatic 
+  # vulnerability checks. the notification, in case you are running a vulnerable version, is shown on the 
+  # admin panel (/?h) and only for users with admin permissions. you can choose between the value given here, 
+  # or alternatively use https://api.copyparty.eu/security-advisories, or your own custom endpoint
+  vc-url: https://api.github.com/repos/9001/copyparty/security-advisories
+
+  # how many seconds to wait between vulnerability checks; default is 86400 (= 1 day).
+  vc-interval: 86400
+
   # p: 80,443,3923   # listen on 80/443 as well (requires CAP_NET_BIND_SERVICE)
   # i: 127.0.0.1     # only allow connections from localhost (reverse-proxies)
   # ftp: 3921        # enable ftp server on port 3921

--- a/copyparty/__main__.py
+++ b/copyparty/__main__.py
@@ -1204,7 +1204,7 @@ def add_general(ap, nc, srvname):
     ap2.add_argument("--license", action="store_true", help="show licenses and exit")
     ap2.add_argument("--version", action="store_true", help="show versions and exit")
     ap2.add_argument("--versionb", action="store_true", help="show version and exit")
-    ap2.add_argument("--vc-url", metavar="URL", type=u, default="", help="URL to check for vulnerable versions (default: None)")
+    ap2.add_argument("--vc-url", metavar="URL", type=u, default="", help="URL to check for vulnerable versions (default: empty/disabled)")
     ap2.add_argument("--vc-interval", metavar="SEC", type=int, default=86400, help="how many seconds to wait between vulnerability checks (default: 86400)")
 
 

--- a/copyparty/__main__.py
+++ b/copyparty/__main__.py
@@ -1201,11 +1201,12 @@ def add_general(ap, nc, srvname):
     ap2.add_argument("--mimes", action="store_true", help="list default mimetype mapping and exit")
     ap2.add_argument("--rmagic", action="store_true", help="do expensive analysis to improve accuracy of returned mimetypes; will make file-downloads, rss, and webdav slower (volflag=rmagic)")
     ap2.add_argument("-j", metavar="CORES", type=int, default=1, help="num cpu-cores for uploads/downloads (0=all); keeping the default is almost always best")
+    ap2.add_argument("--vc-url", metavar="URL", type=u, default="", help="URL to check for vulnerable versions (default-disabled)")
+    ap2.add_argument("--vc-age", metavar="HOURS", type=int, default=3, help="how many hours to wait between vulnerability checks")
+    ap2.add_argument("--vc-exit", action="store_true", help="panic and exit if current version is vulnerable")
     ap2.add_argument("--license", action="store_true", help="show licenses and exit")
     ap2.add_argument("--version", action="store_true", help="show versions and exit")
     ap2.add_argument("--versionb", action="store_true", help="show version and exit")
-    ap2.add_argument("--vc-url", metavar="URL", type=u, default="", help="URL to check for vulnerable versions (default: empty/disabled)")
-    ap2.add_argument("--vc-interval", metavar="SEC", type=int, default=86400, help="how many seconds to wait between vulnerability checks (default: 86400)")
 
 
 def add_qr(ap, tty):

--- a/copyparty/__main__.py
+++ b/copyparty/__main__.py
@@ -1204,6 +1204,8 @@ def add_general(ap, nc, srvname):
     ap2.add_argument("--license", action="store_true", help="show licenses and exit")
     ap2.add_argument("--version", action="store_true", help="show versions and exit")
     ap2.add_argument("--versionb", action="store_true", help="show version and exit")
+    ap2.add_argument("--vc-url", metavar="URL", type=u, default="", help="URL to check for vulnerable versions (default: None)")
+    ap2.add_argument("--vc-interval", metavar="SEC", type=int, default=86400, help="how many seconds to wait between vulnerability checks (default: 86400)")
 
 
 def add_qr(ap, tty):

--- a/copyparty/broker_mp.py
+++ b/copyparty/broker_mp.py
@@ -157,6 +157,10 @@ class BrokerMp(object):
         elif dest == "cb_httpsrv_up":
             self.hub.cb_httpsrv_up()
 
+        elif dest == "httpsrv.set_bad_ver":
+            for p in self.procs:
+                p.q_pend.put((0, dest, list(args)))
+
         else:
             raise Exception("what is " + str(dest))
 

--- a/copyparty/broker_thr.py
+++ b/copyparty/broker_thr.py
@@ -61,6 +61,10 @@ class BrokerThr(BrokerCli):
             self.httpsrv.set_netdevs(args[0])
             return
 
+        if dest == "httpsrv.set_bad_ver":
+            self.httpsrv.set_bad_ver(args[0])
+            return
+
         # new ipc invoking managed service in hub
         obj = self.hub
         for node in dest.split("."):

--- a/copyparty/broker_thr.py
+++ b/copyparty/broker_thr.py
@@ -53,17 +53,18 @@ class BrokerThr(BrokerCli):
         return NotExQueue(obj(*args))  # type: ignore
 
     def say(self, dest: str, *args: Any) -> None:
-        if dest == "httpsrv.listen":
-            self.httpsrv.listen(args[0], 1)
-            return
+        if dest.startswith("httpsrv."):
+            if dest == "httpsrv.listen":
+                self.httpsrv.listen(args[0], 1)
+                return
 
-        if dest == "httpsrv.set_netdevs":
-            self.httpsrv.set_netdevs(args[0])
-            return
+            if dest == "httpsrv.set_netdevs":
+                self.httpsrv.set_netdevs(args[0])
+                return
 
-        if dest == "httpsrv.set_bad_ver":
-            self.httpsrv.set_bad_ver(args[0])
-            return
+            if dest == "httpsrv.set_bad_ver":
+                self.httpsrv.set_bad_ver()
+                return
 
         # new ipc invoking managed service in hub
         obj = self.hub

--- a/copyparty/httpcli.py
+++ b/copyparty/httpcli.py
@@ -156,7 +156,7 @@ BADXFF = " due to dangerous misconfiguration (the http-header specified by --xff
 BADXFF2 = ". Some copyparty features are now disabled as a safety measure.\n\n\n"
 BADXFP = ', or change the copyparty global-option "xf-proto" to another header-name to read this value from. Alternatively, if your reverseproxy is not able to provide a header similar to "X-Forwarded-Proto", then you must tell copyparty which protocol to assume; either "--xf-proto-fb=http" or "--xf-proto-fb=https"'
 BADXFFB = "<div class='box-warning'>NOTE: serverlog has a message regarding your reverse-proxy config</div>"
-BADVER = "<div class='box-warning'>The version of copyparty currently active has a known vulnerability <a class='unbox' href='https://github.com/9001/copyparty/security'>(more info)</a> that has been fixed; please update to the latest version. This message is only visible to users with admin (a/A) permissions.</div>"
+BADVER = "<div class='box-warning'>The version of copyparty currently active has a known vulnerability <a class='unbox' href='https://github.com/9001/copyparty/security'>(more info)</a> that has been fixed; please update to the latest version. This message is only visible to users with the admin (a or A) permission.</div>"
 
 H_CONN_KEEPALIVE = "Connection: Keep-Alive"
 H_CONN_CLOSE = "Connection: Close"

--- a/copyparty/httpcli.py
+++ b/copyparty/httpcli.py
@@ -155,8 +155,8 @@ ALL_COOKIES = "k304 no304 js idxh dots cppwd cppws".split()
 BADXFF = " due to dangerous misconfiguration (the http-header specified by --xff-hdr was received from an untrusted reverse-proxy)"
 BADXFF2 = ". Some copyparty features are now disabled as a safety measure.\n\n\n"
 BADXFP = ', or change the copyparty global-option "xf-proto" to another header-name to read this value from. Alternatively, if your reverseproxy is not able to provide a header similar to "X-Forwarded-Proto", then you must tell copyparty which protocol to assume; either "--xf-proto-fb=http" or "--xf-proto-fb=https"'
-BADXFFB = "<div class='box-warning'>NOTE: serverlog has a message regarding your reverse-proxy config</div>"
-BADVER = "<div class='box-warning'>The version of copyparty currently active has a known vulnerability <a class='unbox' href='https://github.com/9001/copyparty/security'>(more info)</a> that has been fixed; please update to the latest version. This message is only visible to users with the admin (a or A) permission.</div>"
+BADXFFB = "<b>NOTE: serverlog has a message regarding your reverse-proxy config</b>"
+BADVER = '<a class="r" href="https://github.com/9001/copyparty/security/advisories">Please upgrade copyparty; Your version has a vulnerability</a><p>(only users with permission "a" or "A" can see this message)</p>'
 
 H_CONN_KEEPALIVE = "Connection: Keep-Alive"
 H_CONN_CLOSE = "Connection: Close"
@@ -5625,8 +5625,13 @@ class HttpCli(object):
             no304=self.no304(),
             k304vis=self.args.k304 > 0,
             no304vis=self.args.no304 > 0,
-            msg=(BADXFFB if not hasattr(self, "bad_xff") else "")
-            + (BADVER if self.conn.hsrv.bad_ver and self.can_admin else ""),
+            msg=(
+                BADVER
+                if self.conn.hsrv.bad_ver and self.can_admin
+                else BADXFFB
+                if hasattr(self, "bad_xff")
+                else ""
+            ),
             ver=S_VERSION if show_ver else "",
             chpw=self.args.chpw and self.uname != "*",
             ahttps="" if self.is_https else "https://" + self.host + self.req,

--- a/copyparty/httpcli.py
+++ b/copyparty/httpcli.py
@@ -155,7 +155,8 @@ ALL_COOKIES = "k304 no304 js idxh dots cppwd cppws".split()
 BADXFF = " due to dangerous misconfiguration (the http-header specified by --xff-hdr was received from an untrusted reverse-proxy)"
 BADXFF2 = ". Some copyparty features are now disabled as a safety measure.\n\n\n"
 BADXFP = ', or change the copyparty global-option "xf-proto" to another header-name to read this value from. Alternatively, if your reverseproxy is not able to provide a header similar to "X-Forwarded-Proto", then you must tell copyparty which protocol to assume; either "--xf-proto-fb=http" or "--xf-proto-fb=https"'
-BADXFFB = "<b>NOTE: serverlog has a message regarding your reverse-proxy config</b>"
+BADXFFB = "<div class='box-warning'>NOTE: serverlog has a message regarding your reverse-proxy config</div>"
+BADVER = "<div class='box-warning'>The version of copyparty currently active has a known vulnerability <a class='unbox' href='https://github.com/9001/copyparty/security'>(more info)</a> that has been fixed; please update to the latest version. This message is only visible to users with admin (a/A) permissions.</div>"
 
 H_CONN_KEEPALIVE = "Connection: Keep-Alive"
 H_CONN_CLOSE = "Connection: Close"
@@ -5624,7 +5625,8 @@ class HttpCli(object):
             no304=self.no304(),
             k304vis=self.args.k304 > 0,
             no304vis=self.args.no304 > 0,
-            msg=BADXFFB if hasattr(self, "bad_xff") else "",
+            msg=(BADXFFB if not hasattr(self, "bad_xff") else "")
+            + (BADVER if self.conn.hsrv.bad_ver and self.can_admin else ""),
             ver=S_VERSION if show_ver else "",
             chpw=self.args.chpw and self.uname != "*",
             ahttps="" if self.is_https else "https://" + self.host + self.req,

--- a/copyparty/httpsrv.py
+++ b/copyparty/httpsrv.py
@@ -119,6 +119,7 @@ class HttpSrv(object):
         socket.setdefaulttimeout(120)
 
         self.t0 = time.time()
+        self.bad_ver = False
         nsuf = "-n{}-i{:x}".format(nid, os.getpid()) if nid else ""
         self.magician = Magician()
         self.nm = NetMap([], [])
@@ -231,6 +232,9 @@ class HttpSrv(object):
 
         self.th_cfg: dict[str, set[str]] = {}
         Daemon(self.post_init, "hsrv-init2")
+
+    def set_bad_ver(self, val: bool) -> None:
+        self.bad_ver = val
 
     def post_init(self) -> None:
         try:

--- a/copyparty/httpsrv.py
+++ b/copyparty/httpsrv.py
@@ -119,7 +119,6 @@ class HttpSrv(object):
         socket.setdefaulttimeout(120)
 
         self.t0 = time.time()
-        self.bad_ver = False
         nsuf = "-n{}-i{:x}".format(nid, os.getpid()) if nid else ""
         self.magician = Magician()
         self.nm = NetMap([], [])
@@ -144,6 +143,7 @@ class HttpSrv(object):
         self.name = "hsrv" + nsuf
         self.mutex = threading.Lock()
         self.u2mutex = threading.Lock()
+        self.bad_ver = False
         self.stopping = False
 
         self.tp_nthr = 0  # actual
@@ -233,15 +233,15 @@ class HttpSrv(object):
         self.th_cfg: dict[str, set[str]] = {}
         Daemon(self.post_init, "hsrv-init2")
 
-    def set_bad_ver(self, val: bool) -> None:
-        self.bad_ver = val
-
     def post_init(self) -> None:
         try:
             x = self.broker.ask("thumbsrv.getcfg")
             self.th_cfg = x.get()
         except:
             pass
+
+    def set_bad_ver(self) -> None:
+        self.bad_ver = True
 
     def set_netdevs(self, netdevs: dict[str, Netdev]) -> None:
         ips = set()

--- a/copyparty/svchub.py
+++ b/copyparty/svchub.py
@@ -1816,7 +1816,7 @@ class SvcHub(object):
                 if time.time() - mtime < self.args.vc_interval:
                     data = read_utf8(None, fpath, True)
             except Exception as e:
-                self.log("ver-chk", "no vulnerability advisory cache found; {}".format(e))
+                self.log("ver-chk", "no cached vulnerability advisory found, fetching; {}".format(e))
 
             if not data:
                 try:

--- a/copyparty/svchub.py
+++ b/copyparty/svchub.py
@@ -1826,7 +1826,7 @@ class SvcHub(object):
             if data:
                 try:
                     advisories = json.loads(data)
-                    
+
                     fixes = (
                         self.parse_version(vuln.get("patched_versions"))
                         for adv in advisories
@@ -1837,7 +1837,7 @@ class SvcHub(object):
 
                     if newest_fix and ver_cpp < newest_fix:
                         self.broker.say("httpsrv.set_bad_ver", True)
-                    
+
                 except Exception as e:
                     self.log("ver-chk", "failed to process vulnerability advisory; {}".format(e))
 

--- a/copyparty/svchub.py
+++ b/copyparty/svchub.py
@@ -108,10 +108,6 @@ VER_IDP_DB = 1
 VER_SESSION_DB = 1
 VER_SHARES_DB = 2
 
-VULN_CHECK_URL = "https://api.github.com/repos/9001/copyparty/security-advisories"
-VULN_CHECK_INTERVAL = 86400
-
-
 class SvcHub(object):
     """
     Hosts all services which cannot be parallelized due to reliance on monolithic resources.
@@ -1810,14 +1806,14 @@ class SvcHub(object):
 
             try:
                 mtime = os.path.getmtime(fpath)
-                if time.time() - mtime < VULN_CHECK_INTERVAL:
+                if time.time() - mtime < self.args.vc_interval:
                     data = read_utf8(None, fpath, True)
             except Exception as e:
                 self.log("ver-chk", "no vulnerability advisory cache found; {}".format(e))
 
             if not data:
                 try:
-                    req = Request(VULN_CHECK_URL)
+                    req = Request(self.args.vc_url)
                     with urlopen(req, timeout=30) as f:
                         data = f.read().decode("utf-8")
 
@@ -1841,10 +1837,11 @@ class SvcHub(object):
 
                     if newest_fix and ver_cpp < newest_fix:
                         self.broker.say("httpsrv.set_bad_ver", True)
+                    
                 except Exception as e:
                     self.log("ver-chk", "failed to process vulnerability advisory; {}".format(e))
 
-            for _ in range(VULN_CHECK_INTERVAL):
+            for _ in range(self.args.vc_interval):
                 if self.stopping:
                     return
                 time.sleep(1)

--- a/copyparty/svchub.py
+++ b/copyparty/svchub.py
@@ -1833,16 +1833,23 @@ class SvcHub(object):
             if data:
                 try:
                     advisories = json.loads(data)
+                    has_vuln = False
 
-                    fixes = (
-                        self.parse_version(vuln.get("patched_versions"))
-                        for adv in advisories
-                        for vuln in adv.get("vulnerabilities", [])
-                        if vuln.get("patched_versions")
-                    )
-                    newest_fix = max(fixes, default=None)
+                    for adv in advisories:
+                        for vuln in adv.get("vulnerabilities", []):
+                            if vuln.get("package", {}).get("name") != "copyparty":
+                                continue
 
-                    if newest_fix and ver_cpp < newest_fix:
+                            patched_str = vuln.get("patched_versions")
+                            if patched_str:
+                                patched_ver = self.parse_version(patched_str)
+                                if ver_cpp < patched_ver:
+                                    has_vuln = True
+                                    break
+                        if has_vuln:
+                            break
+
+                    if has_vuln:
                         self.broker.say("httpsrv.set_bad_ver", True)
 
                 except Exception as e:

--- a/copyparty/svchub.py
+++ b/copyparty/svchub.py
@@ -4,6 +4,7 @@ from __future__ import print_function, unicode_literals
 import argparse
 import atexit
 import errno
+import json
 import logging
 import os
 import re
@@ -27,6 +28,7 @@ if True:  # pylint: disable=using-constant-test
     from typing import Any, Optional, Union
 
 from .__init__ import ANYWIN, EXE, MACOS, PY2, TYPE_CHECKING, E, EnvParams, unicode
+from .__version__ import S_VERSION
 from .authsrv import BAD_CFG, AuthSrv, derive_args, n_du_who, n_ver_who
 from .bos import bos
 from .cert import ensure_cert
@@ -75,6 +77,7 @@ from .util import (
     mp,
     odfusion,
     pybin,
+    read_utf8,
     start_log_thrs,
     start_stackmon,
     termsize,
@@ -95,10 +98,18 @@ if TYPE_CHECKING:
 if PY2:
     range = xrange  # type: ignore
 
+if PY2:
+    from urllib2 import Request, urlopen
+else:
+    from urllib.request import Request, urlopen
+
 
 VER_IDP_DB = 1
 VER_SESSION_DB = 1
 VER_SHARES_DB = 2
+
+VULN_CHECK_URL = "https://api.github.com/repos/9001/copyparty/security-advisories"
+VULN_CHECK_INTERVAL = 86400
 
 
 class SvcHub(object):
@@ -1382,6 +1393,7 @@ class SvcHub(object):
             Daemon(self.tcpsrv.netmon, "netmon")
 
         Daemon(self.thr_httpsrv_up, "sig-hsrv-up2")
+        Daemon(self.check_ver, "ver-chk")
 
         sigs = [signal.SIGINT, signal.SIGTERM]
         if not ANYWIN:
@@ -1778,3 +1790,61 @@ class SvcHub(object):
         zb = gzip.compress(zb)
         zs = ub64enc(zb).decode("ascii")
         self.log("stacks", zs)
+
+    def parse_version(self, ver: str) -> tuple:
+        match = re.search(r'[\d.]+', ver)
+        if not match:
+            return ()
+        clean = match.group(0).strip('.')
+        return tuple(int(x) for x in clean.split("."))
+
+    def get_vuln_cache_path(self) -> str:
+        return os.path.join(self.E.cfg, "vuln_advisory.json")
+
+    def check_ver(self) -> None:
+        ver_cpp = self.parse_version(S_VERSION)
+
+        while not self.stopping:
+            fpath = self.get_vuln_cache_path()
+            data = None
+
+            try:
+                mtime = os.path.getmtime(fpath)
+                if time.time() - mtime < VULN_CHECK_INTERVAL:
+                    data = read_utf8(None, fpath, True)
+            except Exception as e:
+                self.log("ver-chk", "no vulnerability advisory cache found; {}".format(e))
+
+            if not data:
+                try:
+                    req = Request(VULN_CHECK_URL)
+                    with urlopen(req, timeout=30) as f:
+                        data = f.read().decode("utf-8")
+
+                    with open(fpath, "wb") as f:
+                        f.write(data.encode("utf-8"))
+
+                except Exception as e:
+                    self.log("ver-chk", "failed to fetch vulnerability advisory; {}".format(e))
+
+            if data:
+                try:
+                    advisories = json.loads(data)
+                    
+                    fixes = (
+                        self.parse_version(vuln.get("patched_versions"))
+                        for adv in advisories
+                        for vuln in adv.get("vulnerabilities", [])
+                        if vuln.get("patched_versions")
+                    )
+                    newest_fix = max(fixes, default=None)
+
+                    if newest_fix and ver_cpp < newest_fix:
+                        self.broker.say("httpsrv.set_bad_ver", True)
+                except Exception as e:
+                    self.log("ver-chk", "failed to process vulnerability advisory; {}".format(e))
+
+            for _ in range(VULN_CHECK_INTERVAL):
+                if self.stopping:
+                    return
+                time.sleep(1)

--- a/copyparty/svchub.py
+++ b/copyparty/svchub.py
@@ -1798,6 +1798,9 @@ class SvcHub(object):
         return os.path.join(self.E.cfg, "vuln_advisory.json")
 
     def check_ver(self) -> None:
+        if not self.args.vc_url:
+            return
+
         ver_cpp = self.parse_version(S_VERSION)
 
         while not self.stopping:

--- a/copyparty/svchub.py
+++ b/copyparty/svchub.py
@@ -1788,11 +1788,15 @@ class SvcHub(object):
         self.log("stacks", zs)
 
     def parse_version(self, ver: str) -> tuple:
+        if not ver or not isinstance(ver, str):
+            return (0, 0, 0)
         match = re.search(r'[\d.]+', ver)
         if not match:
             return (0, 0, 0)
-        clean = match.group(0).strip('.')
-        return tuple(int(x) for x in clean.split("."))
+        parts = [int(x) for x in match.group(0).split(".")]
+        while len(parts) < 3:
+            parts.append(0)
+        return tuple(parts[:3])
 
     def get_vuln_cache_path(self) -> str:
         return os.path.join(self.E.cfg, "vuln_advisory.json")

--- a/copyparty/svchub.py
+++ b/copyparty/svchub.py
@@ -28,7 +28,7 @@ if True:  # pylint: disable=using-constant-test
     from typing import Any, Optional, Union
 
 from .__init__ import ANYWIN, EXE, MACOS, PY2, TYPE_CHECKING, E, EnvParams, unicode
-from .__version__ import S_VERSION
+from .__version__ import S_VERSION, VERSION
 from .authsrv import BAD_CFG, AuthSrv, derive_args, n_du_who, n_ver_who
 from .bos import bos
 from .cert import ensure_cert
@@ -107,6 +107,7 @@ else:
 VER_IDP_DB = 1
 VER_SESSION_DB = 1
 VER_SHARES_DB = 2
+
 
 class SvcHub(object):
     """
@@ -1389,7 +1390,8 @@ class SvcHub(object):
             Daemon(self.tcpsrv.netmon, "netmon")
 
         Daemon(self.thr_httpsrv_up, "sig-hsrv-up2")
-        Daemon(self.check_ver, "ver-chk")
+        if self.args.vc_url:
+            Daemon(self.check_ver, "ver-chk")
 
         sigs = [signal.SIGINT, signal.SIGTERM]
         if not ANYWIN:
@@ -1787,75 +1789,78 @@ class SvcHub(object):
         zs = ub64enc(zb).decode("ascii")
         self.log("stacks", zs)
 
-    def parse_version(self, ver: str) -> tuple:
-        if not ver or not isinstance(ver, str):
-            return (0, 0, 0)
-        match = re.search(r'[\d.]+', ver)
-        if not match:
-            return (0, 0, 0)
-        parts = [int(x) for x in match.group(0).split(".")]
-        while len(parts) < 3:
-            parts.append(0)
-        return tuple(parts[:3])
-
-    def get_vuln_cache_path(self) -> str:
-        return os.path.join(self.E.cfg, "vuln_advisory.json")
-
     def check_ver(self) -> None:
-        if not self.args.vc_url:
-            return
-
-        ver_cpp = self.parse_version(S_VERSION)
-
+        next_chk = 0
+        # self.args.vc_age = 2 / 60
+        fpath = os.path.join(self.E.cfg, "vuln_advisory.json")
         while not self.stopping:
-            fpath = self.get_vuln_cache_path()
-            data = None
+            now = time.time()
+            if now < next_chk:
+                time.sleep(min(999, next_chk - now))
+                continue
 
+            age = 0
+            jtxt = ""
+            src = "[cache] "
             try:
                 mtime = os.path.getmtime(fpath)
-                if time.time() - mtime < self.args.vc_interval:
-                    data = read_utf8(None, fpath, True)
+                age = time.time() - mtime
+                if age < self.args.vc_age * 3600 - 69:
+                    zs, jtxt = read_utf8(None, fpath, True).split("\n", 1)
+                    if zs != self.args.vc_url:
+                        jtxt = ""
             except Exception as e:
-                self.log("ver-chk", "no cached vulnerability advisory found, fetching; {}".format(e))
+                t = "will download advisory because cache-file %r could not be read: %s"
+                self.log("ver-chk", t % (fpath, e), 6)
 
-            if not data:
+            if not jtxt:
+                src = ""
+                age = 0
                 try:
                     req = Request(self.args.vc_url)
                     with urlopen(req, timeout=30) as f:
-                        data = f.read().decode("utf-8")
-
-                    with open(fpath, "wb") as f:
-                        f.write(data.encode("utf-8"))
-
+                        jtxt = f.read().decode("utf-8")
+                    try:
+                        with open(fpath, "wb") as f:
+                            zs = self.args.vc_url + "\n" + jtxt
+                            f.write(zs.encode("utf-8"))
+                    except Exception as e:
+                        t = "failed to write advisory to cache; %s"
+                        self.log("ver-chk", t % (e,), 3)
                 except Exception as e:
-                    self.log("ver-chk", "failed to fetch vulnerability advisory; {}".format(e))
+                    t = "failed to fetch vulnerability advisory; %s"
+                    self.log("ver-chk", t % (e,), 1)
 
-            if data:
-                try:
-                    advisories = json.loads(data)
-                    has_vuln = False
+            next_chk = time.time() + 699
+            if not jtxt:
+                continue
 
-                    for adv in advisories:
-                        for vuln in adv.get("vulnerabilities", []):
-                            if vuln.get("package", {}).get("name") != "copyparty":
-                                continue
-
-                            patched_str = vuln.get("patched_versions")
-                            if patched_str:
-                                patched_ver = self.parse_version(patched_str)
-                                if ver_cpp < patched_ver:
-                                    has_vuln = True
-                                    break
-                        if has_vuln:
+            try:
+                advisories = json.loads(jtxt)
+                for adv in advisories:
+                    if adv.get("state") == "closed":
+                        continue
+                    vuln = {}
+                    for x in adv["vulnerabilities"]:
+                        if x["package"]["name"].lower() == "copyparty":
+                            vuln = x
                             break
-
-                    if has_vuln:
-                        self.broker.say("httpsrv.set_bad_ver", True)
-
-                except Exception as e:
-                    self.log("ver-chk", "failed to process vulnerability advisory; {}".format(e))
-
-            for _ in range(self.args.vc_interval):
-                if self.stopping:
-                    return
-                time.sleep(1)
+                    if not vuln:
+                        continue
+                    sver = vuln["patched_versions"].strip(".v")
+                    tver = tuple([int(x) for x in sver.split(".")])
+                    if VERSION < tver:
+                        zs = json.dumps(adv, indent=2)
+                        t = "your version (%s) has a vulnerability! please upgrade:\n%s"
+                        self.log("ver-chk", t % (S_VERSION, zs), 1)
+                        self.broker.say("httpsrv.set_bad_ver")
+                        if self.args.vc_exit:
+                            self.shutdown()
+                        return
+                    else:
+                        t = "%sok; v%s and newer is safe"
+                        self.log("ver-chk", t % (src, sver), 2)
+                next_chk = time.time() + self.args.vc_age * 3600 - age
+            except Exception as e:
+                t = "failed to process vulnerability advisory; %s"
+                self.log("ver-chk", t % (min_ex()), 1)

--- a/copyparty/svchub.py
+++ b/copyparty/svchub.py
@@ -1790,7 +1790,7 @@ class SvcHub(object):
     def parse_version(self, ver: str) -> tuple:
         match = re.search(r'[\d.]+', ver)
         if not match:
-            return ()
+            return (0, 0, 0)
         clean = match.group(0).strip('.')
         return tuple(int(x) for x in clean.split("."))
 

--- a/copyparty/web/splash.css
+++ b/copyparty/web/splash.css
@@ -257,3 +257,19 @@ html.bz {
 html.bz .vols img {
 	filter: sepia(0.8) hue-rotate(180deg);
 }
+.box-warning {
+	background: #804;
+	border-bottom: 1px solid #c28;
+	padding: .75em;
+	text-align: center;
+	border-radius: .2em;
+	margin-top: 0em;
+}
+.box-warning + .box-warning {
+	margin-top: .5em;
+}
+.unbox {
+	border: unset !important;
+	padding: unset !important;
+	margin: unset !important;
+}

--- a/copyparty/web/splash.css
+++ b/copyparty/web/splash.css
@@ -257,11 +257,3 @@ html.bz {
 html.bz .vols img {
 	filter: sepia(0.8) hue-rotate(180deg);
 }
-.box-warning {
-	background: #804;
-	border-bottom: 1px solid #c28;
-	padding: .75em;
-	text-align: center;
-	border-radius: .2em;
-	margin-top: 0em;
-}

--- a/copyparty/web/splash.css
+++ b/copyparty/web/splash.css
@@ -265,11 +265,3 @@ html.bz .vols img {
 	border-radius: .2em;
 	margin-top: 0em;
 }
-.box-warning + .box-warning {
-	margin-top: .5em;
-}
-.unbox {
-	border: unset !important;
-	padding: unset !important;
-	margin: unset !important;
-}

--- a/docs/chungus.conf
+++ b/docs/chungus.conf
@@ -57,6 +57,15 @@
 
   # show versions and exit
   version
+ 
+  # url to check against for vulnerable versions (default disabled); setting this will enable automatic 
+  # vulnerability checks. the notification, in case you are running a vulnerable version, is shown on the 
+  # admin panel (/?h) and only for users with admin permissions. you can choose between the value given here, 
+  # or alternatively use https://api.copyparty.eu/security-advisories, or your own custom endpoint
+  vc-url: https://api.github.com/repos/9001/copyparty/security-advisories
+
+  # how many seconds to wait between vulnerability checks; default is 86400 (= 1 day).
+  vc-interval: 86400
 
   ###000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000\
   ###// qr options \\000000000000000000000000000000000000000000000000000000000000000000000000000\


### PR DESCRIPTION
if `vc-url` is set:
- reads ~/.config/vuln_advisory.json for vulnerability info if it is less than `vc-interval` old
- otherwise checks `vc-url` for a json containing vulnerability info as in https://api.github.com/repos/9001/copyparty/security-advisories
- if found, writes the response to ~/.config/vuln_advisory.json
- if the current version is vulnerable, lets the rest of the program know, if not, hits the bed for a day

or at least I hope that's what it does, I may have made some assumptions that may or may not be regarded, waiting warmly for review. i did test it and it seemed to work but i'm not really testerman so wouldn't be surprised if i overlooked something

This PR complies with the DCO; https://developercertificate.org/  
