### PR TITLE
fix(rotf): dupe file creation by stripping trailing slashes

### DIFF
--- a/copyparty/authsrv.py
+++ b/copyparty/authsrv.py
@@ -190,12 +190,12 @@ class Lim(object):
             self.log_func("up-lim", msg, c)
 
     def set_rotf(self, fmt: str, tz: str) -> None:
-        self.rotf = fmt
+        self.rotf = fmt.rstrip("/\\")
         if tz != "UTC":
             from zoneinfo import ZoneInfo
 
             self.rotf_tz = ZoneInfo(tz)
-        r = re.escape(fmt).replace("%Y", "[0-9]{4}").replace("%j", "[0-9]{3}")
+        r = re.escape(self.rotf).replace("%Y", "[0-9]{4}").replace("%j", "[0-9]{3}")
         r = re.sub("%[mdHMSWU]", "[0-9]{2}", r)
         self.rot_re = re.compile("(^|/)" + r + "$")
 


### PR DESCRIPTION
`rotf` is meant to be a directory abstraction, so it’s easy to assume that adding a trailing slash like:

```
%Y/%m/%d/
```
should be fine, just like writing a folder path with `/` at the end.

Right now, that trailing slash makes `copyparty` treat the same folder as two different paths, which can cause duplicate uploads (and confusion, in my case) with `up2k`. Stripping trailing slashes just makes the behavior consistent and prevents these surprises.

Fixes #1334

---

This PR complies with the DCO; https://developercertificate.org/  
