### PR TITLE
feat: support .hidden file for dotfiles exclusion

### DIFF
--- a/copyparty/ftpd.py
+++ b/copyparty/ftpd.py
@@ -24,6 +24,7 @@ from .util import (
     ODict,
     Pebkac,
     exclude_dotfiles,
+    load_dothidden,
     fsenc,
     ipnorm,
     pybin,
@@ -348,7 +349,8 @@ class FtpFs(AbstractedFS):
             vfs_ls.extend(vfs_virt.keys())
 
             if self.uname not in vfs.axs.udot:
-                vfs_ls = exclude_dotfiles(vfs_ls)
+                dothidden = load_dothidden(fsroot)
+                vfs_ls = exclude_dotfiles(vfs_ls, dothidden)
 
             vfs_ls.sort()
             return vfs_ls

--- a/copyparty/ftpd.py
+++ b/copyparty/ftpd.py
@@ -24,7 +24,7 @@ from .util import (
     ODict,
     Pebkac,
     exclude_dotfiles,
-    load_dothidden,
+    exclude_dothidden,
     fsenc,
     ipnorm,
     pybin,
@@ -349,8 +349,10 @@ class FtpFs(AbstractedFS):
             vfs_ls.extend(vfs_virt.keys())
 
             if self.uname not in vfs.axs.udot:
-                dothidden = load_dothidden(fsroot)
-                vfs_ls = exclude_dotfiles(vfs_ls, dothidden)
+                if "dothidden" in vfs.flags and ".hidden" in [x[0] for x in vfs_ls]:
+                    vfs_ls = exclude_dothidden(vfs_ls, fsroot)
+                else:
+                    vfs_ls = exclude_dotfiles(vfs_ls)
 
             vfs_ls.sort()
             return vfs_ls

--- a/copyparty/httpcli.py
+++ b/copyparty/httpcli.py
@@ -80,6 +80,7 @@ from .util import (
     has_resource,
     hashcopy,
     hidedir,
+    load_dothidden,
     html_bescape,
     html_escape,
     html_sh_esc,
@@ -1845,13 +1846,14 @@ class HttpCli(object):
             if not self.can_read:
                 vfs_ls = []
             if not self.can_dot:
-                vfs_ls = exclude_dotfiles_ls(vfs_ls)
+                dothidden = load_dothidden(vn.canonical(rem))
+                vfs_ls = exclude_dotfiles_ls(vfs_ls, dothidden)
             fgen = [{"vp": vp, "st": st} for vp, st in vfs_ls]
 
             if vfs_virt:
                 zsl = list(vfs_virt)
                 if not self.can_dot:
-                    zsl = exclude_dotfiles(zsl)
+                    zsl = exclude_dotfiles(zsl, dothidden)
                 fgen += [{"vp": v, "st": vst} for v in zsl]
 
         else:
@@ -5852,9 +5854,10 @@ class HttpCli(object):
                     vfs_virt[d2] = vfs  # typechk, value never read
 
         dirs = [x[0] for x in vfs_ls if stat.S_ISDIR(x[1].st_mode)]
+        dothidden = load_dothidden(fsroot) if fsroot else None
 
         if not dots:
-            dirs = exclude_dotfiles(dirs)
+            dirs = exclude_dotfiles(dirs, dothidden)
 
         dirs = [quotep(x) for x in dirs if x != excl]
 
@@ -5884,7 +5887,7 @@ class HttpCli(object):
                     x += "\n"
                 dirs.append(quotep(x))
             if not dots:
-                dirs = exclude_dotfiles(dirs)
+                dirs = exclude_dotfiles(dirs, dothidden)
 
         ret["a"] = dirs
         return ret
@@ -7134,7 +7137,8 @@ class HttpCli(object):
         if not self.can_dot or (
             "dots" not in self.uparam and (is_ls or "dots" not in self.cookies)
         ):
-            ls_names = exclude_dotfiles(ls_names)
+            dothidden = load_dothidden(fsroot)
+            ls_names = exclude_dotfiles(ls_names, dothidden)
 
         add_dk = vf.get("dk")
         add_fk = vf.get("fk")

--- a/copyparty/httpcli.py
+++ b/copyparty/httpcli.py
@@ -65,6 +65,8 @@ from .util import (
     eol_conv,
     exclude_dotfiles,
     exclude_dotfiles_ls,
+    exclude_dothidden,
+    exclude_dothidden_ls,
     formatdate,
     fsenc,
     gen_content_disposition,
@@ -1835,7 +1837,7 @@ class HttpCli(object):
                 raise Pebkac(401, "authenticate")
 
         elif depth == "1":
-            _, vfs_ls, vfs_virt = vn.ls(
+            fsroot, vfs_ls, vfs_virt = vn.ls(
                 rem,
                 self.uname,
                 not self.args.no_scandir,
@@ -1846,14 +1848,20 @@ class HttpCli(object):
             if not self.can_read:
                 vfs_ls = []
             if not self.can_dot:
-                dothidden = load_dothidden(vn.canonical(rem))
-                vfs_ls = exclude_dotfiles_ls(vfs_ls, dothidden)
+                if "dothidden" in vn.flags and ".hidden" in [x[0] for x in vfs_ls]:
+                    vfs_ls = exclude_dothidden_ls(vfs_ls, fsroot)
+                    self.dothid = True
+                else:
+                    vfs_ls = exclude_dotfiles_ls(vfs_ls)
             fgen = [{"vp": vp, "st": st} for vp, st in vfs_ls]
 
             if vfs_virt:
                 zsl = list(vfs_virt)
                 if not self.can_dot:
-                    zsl = exclude_dotfiles(zsl, dothidden)
+                    if "dothidden" in vn.flags and getattr(self, "dothid", False):
+                        zsl = exclude_dothidden(zsl, fsroot)
+                    else:
+                        zsl = exclude_dotfiles(zsl)
                 fgen += [{"vp": v, "st": vst} for v in zsl]
 
         else:
@@ -5846,6 +5854,7 @@ class HttpCli(object):
             dk_sz = vn.flags.get("dk")
         except:
             dk_sz = None
+            vn = vfs
             vfs_ls = []
             vfs_virt = {}
             for v in self.rvol:
@@ -5854,10 +5863,13 @@ class HttpCli(object):
                     vfs_virt[d2] = vfs  # typechk, value never read
 
         dirs = [x[0] for x in vfs_ls if stat.S_ISDIR(x[1].st_mode)]
-        dothidden = load_dothidden(fsroot) if fsroot else None
 
         if not dots:
-            dirs = exclude_dotfiles(dirs, dothidden)
+            if "dothidden" in vn.flags and ".hidden" in [x[0] for x in vfs_ls]:
+                dirs = exclude_dothidden(dirs, fsroot)
+                self.dothid = True
+            else:
+                dirs = exclude_dotfiles(dirs)
 
         dirs = [quotep(x) for x in dirs if x != excl]
 
@@ -5887,7 +5899,10 @@ class HttpCli(object):
                     x += "\n"
                 dirs.append(quotep(x))
             if not dots:
-                dirs = exclude_dotfiles(dirs, dothidden)
+                if "dothidden" in vn.flags and getattr(self, "dothid", False):
+                    dirs = exclude_dothidden(dirs, fsroot)
+                else:
+                    dirs = exclude_dotfiles(dirs)
 
         ret["a"] = dirs
         return ret
@@ -7137,8 +7152,10 @@ class HttpCli(object):
         if not self.can_dot or (
             "dots" not in self.uparam and (is_ls or "dots" not in self.cookies)
         ):
-            dothidden = load_dothidden(fsroot)
-            ls_names = exclude_dotfiles(ls_names, dothidden)
+            if "dothidden" in vf and ".hidden" in ls_names:
+                ls_names = exclude_dothidden(ls_names, fsroot)
+            else:
+                ls_names = exclude_dotfiles(ls_names)
 
         add_dk = vf.get("dk")
         add_fk = vf.get("fk")

--- a/copyparty/tftpd.py
+++ b/copyparty/tftpd.py
@@ -42,6 +42,7 @@ from .util import (
     Daemon,
     ODict,
     exclude_dotfiles,
+    load_dothidden,
     min_ex,
     runhook,
     set_fperms,
@@ -318,7 +319,8 @@ class Tftpd(object):
         ls = virs + reals
 
         if "*" not in vn.axs.udot:
-            names = set(exclude_dotfiles([x[2] for x in ls]))
+            dothidden = load_dothidden(fsroot)
+            names = set(exclude_dotfiles([x[2] for x in ls], dothidden))
             ls = [x for x in ls if x[2] in names]
 
         try:

--- a/copyparty/tftpd.py
+++ b/copyparty/tftpd.py
@@ -42,7 +42,7 @@ from .util import (
     Daemon,
     ODict,
     exclude_dotfiles,
-    load_dothidden,
+    exclude_dothidden,
     min_ex,
     runhook,
     set_fperms,
@@ -319,8 +319,11 @@ class Tftpd(object):
         ls = virs + reals
 
         if "*" not in vn.axs.udot:
-            dothidden = load_dothidden(fsroot)
-            names = set(exclude_dotfiles([x[2] for x in ls], dothidden))
+            zsl = [x[2] for x in ls]
+            if "dothidden" in vn.flags and ".hidden" in zsl:
+                names = set(exclude_dothidden(zsl, fsroot))
+            else:
+                names = set(exclude_dotfiles(zsl))
             ls = [x for x in ls if x[2] in names]
 
         try:

--- a/copyparty/util.py
+++ b/copyparty/util.py
@@ -2381,6 +2381,13 @@ def u8safe(txt: str) -> str:
     except:
         return txt.encode("utf-8", "replace").decode("utf-8", "replace")
 
+def load_dothidden(dpath: str) -> set[str]:
+    try:
+        with open(os.path.join(dpath, ".hidden"), "rb") as f:
+            return {ln.strip() for ln in f.read().decode("utf-8", "replace").splitlines()}
+    except OSError:
+        return {}
+
 
 def exclude_dotfiles(filepaths: list[str]) -> list[str]:
     return [x for x in filepaths if not x.split("/")[-1].startswith(".")]

--- a/copyparty/util.py
+++ b/copyparty/util.py
@@ -2389,14 +2389,22 @@ def load_dothidden(dpath: str) -> set[str]:
         return {}
 
 
-def exclude_dotfiles(filepaths: list[str]) -> list[str]:
-    return [x for x in filepaths if not x.split("/")[-1].startswith(".")]
+def exclude_dotfiles(filepaths: list[str], dothidden: Optional[set[str]] = None) -> list[str]:
+    return [
+        x for x in filepaths
+        if not x.split("/")[-1].startswith(".")
+        and (dothidden is None or x.split("/")[-1] not in dothidden)
+    ]
 
 
 def exclude_dotfiles_ls(
-    vfs_ls: list[tuple[str, os.stat_result]]
+    vfs_ls: list[tuple[str, os.stat_result]], dothidden: Optional[set[str]] = None
 ) -> list[tuple[str, os.stat_result]]:
-    return [x for x in vfs_ls if not x[0].split("/")[-1].startswith(".")]
+    return [
+        x for x in vfs_ls
+        if not x[0].split("/")[-1].startswith(".")
+        and (dothidden is None or x[0].split("/")[-1] not in dothidden)
+    ]
 
 
 def odfusion(

--- a/copyparty/util.py
+++ b/copyparty/util.py
@@ -2381,30 +2381,42 @@ def u8safe(txt: str) -> str:
     except:
         return txt.encode("utf-8", "replace").decode("utf-8", "replace")
 
-def load_dothidden(dpath: str) -> set[str]:
-    try:
-        with open(os.path.join(dpath, ".hidden"), "rb") as f:
-            return {ln.strip() for ln in f.read().decode("utf-8", "replace").splitlines()}
-    except OSError:
-        return {}
 
-
-def exclude_dotfiles(filepaths: list[str], dothidden: Optional[set[str]] = None) -> list[str]:
-    return [
-        x for x in filepaths
-        if not x.split("/")[-1].startswith(".")
-        and (dothidden is None or x.split("/")[-1] not in dothidden)
-    ]
+def exclude_dotfiles(filepaths: list[str]) -> list[str]:
+    return [x for x in filepaths if not x.split("/")[-1].startswith(".")]
 
 
 def exclude_dotfiles_ls(
-    vfs_ls: list[tuple[str, os.stat_result]], dothidden: Optional[set[str]] = None
+    vfs_ls: list[tuple[str, os.stat_result]]
 ) -> list[tuple[str, os.stat_result]]:
-    return [
-        x for x in vfs_ls
-        if not x[0].split("/")[-1].startswith(".")
-        and (dothidden is None or x[0].split("/")[-1] not in dothidden)
-    ]
+    return [x for x in vfs_ls if not x[0].split("/")[-1].startswith(".")]
+
+
+def exclude_dothidden(filepaths: list[str], fsroot: Any) -> list[str]:
+    ret = [x for x in filepaths if not x.split("/")[-1].startswith(".")]
+    filt = load_dothidden(fsroot)
+    if filt:
+        ret = [x for x in ret if x.split("/")[-1] not in filt]
+    return ret
+
+
+def exclude_dothidden_ls(
+    vfs_ls: list[tuple[str, os.stat_result]], fsroot: Any
+) -> list[tuple[str, os.stat_result]]:
+    ret = [x for x in vfs_ls if not x[0].split("/")[-1].startswith(".")]
+    filt = load_dothidden(fsroot)
+    if filt:
+        ret = [x for x in ret if x[0].split("/")[-1] not in filt]
+    return ret
+
+
+def load_dothidden(dpath: str) -> list[str]:
+    try:
+        with open(os.path.join(dpath, ".hidden"), "rb") as f:
+            zsl = f.read().decode("utf-8").splitlines()
+        return [x.strip() for x in zsl]
+    except OSError:
+        return []
 
 
 def odfusion(


### PR DESCRIPTION
Add support for a per-directory `.hidden` file to exclude additional files/directories from listings.

- looks for a .hidden file in each directory being listed
- reads filenames from .hidden if it exists
- excludes any files or folders listed in `.hidden` from listings
- still hides normal dotfiles as before
- if no `.hidden` file exists, behavior is unchanged

### Example directory:

```text
/dir
├─ subdir/
│  ├─ lost+found/
│  └─ file2.txt
├─ lost+found/
├─ .secret
├─ .hidden  (contains "hidden.txt" and "lost+found")
├─ file1.txt
├─ hidden.txt
└─ lost+found.txt
```

### Resulting listing:

```text
/dir
├─ subdir/
│  ├─ lost+found/  (not hidden)
│  └─ file2.txt
├─ file1.txt
└─ lost+found.txt
```

---

This PR complies with the DCO; https://developercertificate.org/  
