### PR TITLE
feat: adding handler for fail2ban

### DIFF
--- a/bin/handlers/404-to-fail2ban.py
+++ b/bin/handlers/404-to-fail2ban.py
@@ -1,16 +1,27 @@
+# /!\ Warning: be careful, as webdav clients often generate a large number of 404 requets.
+
 # In your `jail.local`, add:
 # [copyparty]
 # enabled = true
+# logtimezone = UTC
 # logpath = /path/to/log/file # or keep the default value if you're using systemd
 
 # Create the `copyparty.conf` file in `filter.d` with the following:
 # [Definition]
-# failregex = ^ fail2ban\s*WARN: <ADDR>$
+# failregex = ^ <ADDR>$
 # ignoreregex =
-# datepattern = ^%%H:%%M:%%S\.%%f
+# datepattern = ^fail2ban: %%Y-%%m-%%dT%%H:%%M:%%S
 
 # First check `--dont-ban`, and if it doesn't match, log the line to be intercepted by fail2ban.
-def main(cli, vn, rem):
+from datetime import datetime, UTC
+def main(cli, vn="", rem=""):
+    now = datetime.now(UTC).isoformat()[:19]
+    msg = "\nfail2ban: %s %s"
+    if not vn and not rem:
+        # got called by --xban
+        cli["log"](msg % (now, cli["ip"]), 3)
+        return {"rc": 0}
+
     cond = cli.args.dont_ban
     if (
         cond == "any"
@@ -21,5 +32,5 @@ def main(cli, vn, rem):
     ):
         return ""
 
-    cli.log_func("fail2ban", f"{cli.ip}", 3)
+    cli.log(msg % (now, cli.ip), 3)
     return ""

--- a/bin/handlers/404-to-fail2ban.py
+++ b/bin/handlers/404-to-fail2ban.py
@@ -1,0 +1,25 @@
+# In your `jail.local`, add:
+# [copyparty]
+# enabled = true
+# logpath = /path/to/log/file # or keep the default value if you're using systemd
+
+# Create the `copyparty.conf` file in `filter.d` with the following:
+# [Definition]
+# failregex = ^ fail2ban\s*WARN: <ADDR>$
+# ignoreregex =
+# datepattern = ^%%H:%%M:%%S\.%%f
+
+# First check `--dont-ban`, and if it doesn't match, log the line to be intercepted by fail2ban.
+def main(cli, vn, rem):
+    cond = cli.args.dont_ban
+    if (
+        cond == "any"
+        or (cond == "auth" and cli.uname != "*")
+        or (cond == "aa" and cli.avol)
+        or (cond == "av" and cli.can_admin)
+        or (cond == "rw" and cli.can_read and cli.can_write)
+    ):
+        return ""
+
+    cli.log_func("fail2ban", f"{cli.ip}", 3)
+    return ""

--- a/bin/handlers/README.md
+++ b/bin/handlers/README.md
@@ -22,10 +22,11 @@ each plugin must define a `main()` which takes 3 arguments;
 
 * [redirect.py](redirect.py) sends an HTTP 301 or 302, redirecting the client to another page/file
 * [randpic.py](randpic.py) redirects `/foo/bar/randpic.jpg` to a random pic in `/foo/bar/`
-* [sorry.py](answer.py) replies with a custom message instead of the usual 404
+* [sorry.py](sorry.py) replies with a custom message instead of the usual 404
 * [nooo.py](nooo.py) replies with an endless noooooooooooooo
 * [never404.py](never404.py) 100% guarantee that 404 will never be a thing again as it automatically creates dummy files whenever necessary
 * [caching-proxy.py](caching-proxy.py) transforms copyparty into a squid/varnish knockoff
+* [404-to-fail2ban.py](404-to-fail2ban.py) creates 404 logs for fail2ban
 
 ## on403
 


### PR DESCRIPTION
Added a handler to process 404 errors with fail2ban.

The handler respects the `--dont-ban` argument and, if necessary, will generate a special log line that will be intercepted by fail2ban.
Thanks to this, no one can spoof the log, and the fail2ban regex is lighter (and therefore faster).

---
This PR complies with the DCO; https://developercertificate.org/
