### PR TITLE
doc: use 2 letters for infinitely higher readability vs abcd

### DIFF
--- a/docs/versus.md
+++ b/docs/versus.md
@@ -86,33 +86,33 @@ the table headers in the matrixes below are the different softwares, with a quic
 
 the softwares,
 
-[a]: https://github.com/9001/copyparty "copyparty"
-[b]: https://github.com/rejetto/hfs2/ "hfs2"
-[c]: https://rejetto.com/hfs/ "hfs3"
-[d]: https://github.com/nextcloud/server "nextcloud"
-[e]: https://github.com/haiwen/seafile "seafile"
-[f]: https://github.com/rclone/rclone "rclone"
-[g]: https://github.com/sigoden/dufs "dufs"
-[h]: https://github.com/chibisafe/chibisafe "chibisafe"
-[i]: https://github.com/kalcaddle/kodbox "kodbox"
-[j]: https://github.com/filebrowser/filebrowser "filebrowser"
-[k]: https://github.com/filegator/filegator "filegator"
-[l]: https://github.com/drakkan/sftpgo "sftpgo"
-[m]: https://github.com/tobychui/arozos "arozos"
+[cp]: https://github.com/9001/copyparty "copyparty"
+[h2]: https://github.com/rejetto/hfs2/ "hfs2"
+[h3]: https://rejetto.com/hfs/ "hfs3"
+[nc]: https://github.com/nextcloud/server "nextcloud"
+[sf]: https://github.com/haiwen/seafile "seafile"
+[rc]: https://github.com/rclone/rclone "rclone"
+[df]: https://github.com/sigoden/dufs "dufs"
+[cs]: https://github.com/chibisafe/chibisafe "chibisafe"
+[kb]: https://github.com/kalcaddle/kodbox "kodbox"
+[fb]: https://github.com/filebrowser/filebrowser "filebrowser"
+[fg]: https://github.com/filegator/filegator "filegator"
+[sg]: https://github.com/drakkan/sftpgo "sftpgo"
+[az]: https://github.com/tobychui/arozos "arozos"
 
-* `a` = [copyparty][a]
-* `b` = [hfs2][b] 🔥
-* `c` = [hfs3][c]
-* `d` = [nextcloud][d]
-* `e` = [seafile][e]
-* `f` = [rclone][f], specifically `rclone serve webdav .`
-* `g` = [dufs][g]
-* `h` = [chibisafe][h]
-* `i` = [kodbox][i]
-* `j` = [filebrowser][j]
-* `k` = [filegator][k]
-* `l` = [sftpgo][l]
-* `m` = [arozos][m]
+* `cp` = [copyparty][cp]
+* `h2` = [hfs2][h2] 🔥
+* `h3` = [hfs3][h3]
+* `nc` = [nextcloud][nc]
+* `sf` = [seafile][sf]
+* `rc` = [rclone][rc], specifically `rclone serve webdav .`
+* `df` = [dufs][df]
+* `cs` = [chibisafe][cs]
+* `kb` = [kodbox][kb]
+* `fb` = [filebrowser][fb]
+* `fg` = [filegator][fg]
+* `sg` = [sftpgo][sg]
+* `az` = [arozos][az]
 
 some softwares not in the matrixes,
 * [updog](#updog)
@@ -134,8 +134,8 @@ symbol legend,
 
 ## general
 
-| feature / software      |[a]|[b]|[c]|[d]|[e]|[f]|[g]|[h]|[i]|[j]|[k]|[l]|[m]|
-| ----------------------- | - | - | - | - | - | - | - | - | - | - | - | - | - |
+| feature / software      |[cp]|[h2]|[h3]|[nc]|[sf]|[rc]|[df]|[cs]|[kb]|[fb]|[fg]|[sg]|[az]|
+| ----------------------- |:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|
 | intuitive UX            |   | ╱ | █ | █ | █ |   | █ | █ | █ | █ | █ | █ | █ |
 | config GUI              |   | █ | █ | █ | █ |   |   | █ | █ | █ |   | █ | █ |
 | good documentation      |   |   | █ | █ | █ | █ | █ |   |   | █ | █ | ╱ | ╱ |
@@ -155,28 +155,28 @@ symbol legend,
 | iOS app                 | ╱ |   |   | █ | █ |   |   |   |   |   |   |   |   |
 
 * `zero setup` = you can get a mostly working setup by just launching the app, without having to install any software or configure whatever
-* `a`/copyparty remarks:
+* `cp`/copyparty remarks:
   * no gui for server settings; only for client-side stuff
   * runs on iOS / iPads using [a-Shell](https://holzschu.github.io/a-Shell_iOS/) (pretty good) or [iSH](https://ish.app/) (very slow) but cannot run in the background and is not able to share all of your phone storage (just a separate dedicated folder)
   * [android app](https://f-droid.org/en/packages/me.ocv.partyup/) is for uploading only
   * no iOS app but has [shortcuts](https://github.com/9001/copyparty#ios-shortcuts) for easy uploading
   * validated on aarch64-BE by [Øl Telecom](http://ol-tele.com/) during eth0:2025; [photo1](https://a.ocv.me/pub/g/nerd-stuff/cpp/servers/aallwinner.jpg?cache) and [diploma](https://a.ocv.me/pub/g/nerd-stuff/cpp/servers/be-ready.png?cache)
   * validated on [SGI IRIX](https://en.wikipedia.org/wiki/IRIX) ([an O2](https://en.wikipedia.org/wiki/SGI_O2)) by [Øl Telecom](http://ol-tele.com/) during 39c3; [photo1](https://a.ocv.me/pub/g/nerd-stuff/cpp/servers/sgi-o2.jpg?cache) and [screenshot](https://a.ocv.me/pub/g/nerd-stuff/cpp/servers/sgi-o2.png?cache)
-* `b`/hfs2 runs on linux through wine
-* `f`/rclone must be started with the command `rclone serve webdav .` or similar
-* `h`/chibisafe has undocumented windows support
-* `l`/sftpgo:
+* `h2`/hfs2 runs on linux through wine
+* `rc`/rclone must be started with the command `rclone serve webdav .` or similar
+* `cs`/chibisafe has undocumented windows support
+* `sg`/sftpgo:
   * Must be launched with a command
   * On Termux, just run `pkg in sftpgo`
-* `m`/arozos has partial windows support
+* `az`/arozos has partial windows support
 
 
 ## file transfer
 
 *the thing that copyparty is actually kinda good at*
 
-| feature / software      |[a]|[b]|[c]|[d]|[e]|[f]|[g]|[h]|[i]|[j]|[k]|[l]|[m]|
-| ----------------------- | - | - | - | - | - | - | - | - | - | - | - | - | - |
+| feature / software      |[cp]|[h2]|[h3]|[nc]|[sf]|[rc]|[df]|[cs]|[kb]|[fb]|[fg]|[sg]|[az]|
+| ----------------------- |:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|
 | download folder as zip  | █ | █ | █ | █ | ╱ |   | █ |   | █ | █ | ╱ | █ | ╱ |
 | download folder as tar  | █ |   |   |   |   |   |   |   |   |   |   |   |   |
 | upload                  | █ | █ | █ | █ | █ | █ | █ | █ | █ | █ | ╱ | █ | █ |
@@ -224,23 +224,23 @@ symbol legend,
 
 * `cloud storage backend` = able to serve files from (and write to) s3 or similar cloud services; `╱` means the software can do this with some help from `rclone mount` as a bridge
 
-* `a`/copyparty can reject uploaded files (based on complex conditions), for example [by extension](https://github.com/9001/copyparty/blob/hovudstraum/bin/hooks/reject-extension.py) or [mimetype](https://github.com/9001/copyparty/blob/hovudstraum/bin/hooks/reject-mimetype.py)
-* `e`/seafile download-as-zip is not streaming; it creates the full zipfile before download can start, and fails on big folders
-* `j`/filebrowser remarks:
+* `cp`/copyparty can reject uploaded files (based on complex conditions), for example [by extension](https://github.com/9001/copyparty/blob/hovudstraum/bin/hooks/reject-extension.py) or [mimetype](https://github.com/9001/copyparty/blob/hovudstraum/bin/hooks/reject-mimetype.py)
+* `sf`/seafile download-as-zip is not streaming; it creates the full zipfile before download can start, and fails on big folders
+* `fg`/filebrowser remarks:
   * can provide checksums for single files on request
   * can probably do extension/mimetype rejection similar to copyparty
-* `k`/filegator download-as-zip is not streaming; it creates the full zipfile before download can start
-* `l`/sftpgo:
+* `fg`/filegator download-as-zip is not streaming; it creates the full zipfile before download can start
+* `sg`/sftpgo:
   * resumable/segmented uploads only over SFTP, not over HTTP
   * upload rules are totals only, not over time
   * can probably do extension/mimetype rejection similar to copyparty
-* `m`/arozos download-as-zip is not streaming; it creates the full zipfile before download can start, and fails on big folders
+* `az`/arozos download-as-zip is not streaming; it creates the full zipfile before download can start, and fails on big folders
 
 
 ## protocols and client support
 
-| feature / software      |[a]|[b]|[c]|[d]|[e]|[f]|[g]|[h]|[i]|[j]|[k]|[l]|[m]|
-| ----------------------- | - | - | - | - | - | - | - | - | - | - | - | - | - |
+| feature / software      |[cp]|[h2]|[h3]|[nc]|[sf]|[rc]|[df]|[cs]|[kb]|[fb]|[fg]|[sg]|[az]|
+| ----------------------- |:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|
 | serve https             | █ |   | █ | █ | █ | █ | █ | █ | █ | █ | █ | █ | █ |
 | serve webdav            | █ |   |   | █ | █ | █ | █ |   | █ |   |   | █ | █ |
 | serve ftp  (tcp)        | █ |   |   |   |   | █ |   |   |   |   |   | █ | █ |
@@ -261,17 +261,17 @@ symbol legend,
 * `mojibake filenames` = filenames decoded with the wrong codec and then reencoded (usually to utf-8), so `宇多田ヒカル` might look like `ëFæ╜ôcâqâJâï`
 * `undecodable filenames` = pure binary garbage which cannot be parsed as utf-8
   * you can successfully play `$'\355\221'` with mpv through mounting a remote copyparty server with rclone, pog
-* `a`/copyparty remarks:
+* `cp`/copyparty remarks:
   * extremely minimal samba/cifs server
   * netscape 4 / ie6 support is mostly listed as a joke altho some people have actually found it useful ([ie4 tho](https://user-images.githubusercontent.com/241032/118192791-fb31fe00-b446-11eb-9647-898ea8efc1f7.png))
-* `l`/sftpgo translates mojibake filenames into valid utf-8 (information loss)
-* `m`/arozos has readonly-support for older browsers; no uploading
+* `sg`/sftpgo translates mojibake filenames into valid utf-8 (information loss)
+* `az`/arozos has readonly-support for older browsers; no uploading
 
 
 ## server configuration
 
-| feature / software      |[a]|[b]|[c]|[d]|[e]|[f]|[g]|[h]|[i]|[j]|[k]|[l]|[m]|
-| ----------------------- | - | - | - | - | - | - | - | - | - | - | - | - | - |
+| feature / software      |[cp]|[h2]|[h3]|[nc]|[sf]|[rc]|[df]|[cs]|[kb]|[fb]|[fg]|[sg]|[az]|
+| ----------------------- |:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|
 | config from cmd args    | █ |   | █ |   |   | █ | █ |   |   | █ |   | ╱ | ╱ |
 | config files            | █ | █ | █ | ╱ | ╱ | █ |   | █ |   | █ | • | ╱ | ╱ |
 | runtime config reload   | █ | █ | █ |   |   |   |   | █ | █ | █ | █ |   | █ |
@@ -282,17 +282,17 @@ symbol legend,
 | folder-rproxy ok        | █ |   | █ |   | █ | █ |   | • | • | █ | • |   | • |
 
 * `folder-rproxy` = reverse-proxying without dedicating an entire (sub)domain, using a subfolder instead
-* `l`/sftpgo:
+* `sg`/sftpgo:
   * config: user can be added by cmd command in [Portable mode](https://docs.sftpgo.com/2.6/cli/#portable-mode); if not in  Portable mode users must be added through gui / api calls
-* `m`/arozos:
+* `az`/arozos:
   * configuration is primarily through GUI
   * reverse-proxy is not guaranteed to see the correct client IP
 
 
 ## server capabilities
 
-| feature / software      |[a]|[b]|[c]|[d]|[e]|[f]|[g]|[h]|[i]|[j]|[k]|[l]|[m]|
-| ----------------------- | - | - | - | - | - | - | - | - | - | - | - | - | - |
+| feature / software      |[cp]|[h2]|[h3]|[nc]|[sf]|[rc]|[df]|[cs]|[kb]|[fb]|[fg]|[sg]|[az]|
+| ----------------------- |:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|
 | accounts                | █ | █ | █ | █ | █ | █ | █ | █ | █ | █ | █ | █ | █ |
 | per-account chroot      |   |   |   |   |   |   |   |   |   |   |   | █ |   |
 | single-sign-on          | ╱ |   |   | █ | █ |   |   |   | • |   |   |   |   |
@@ -337,7 +337,7 @@ symbol legend,
 * `speed throttle` = rate limiting (per ip, per user, per connection, anything like that)
 * `curl-friendly ls` = returns a [sortable plaintext folder listing](https://user-images.githubusercontent.com/241032/215322619-ea5fd606-3654-40ad-94ee-2bc058647bb2.png) when curled
 * `curl-friendly upload` = uploading with curl is just `curl -T some.bin http://.../`
-* `a`/copyparty remarks:
+* `cp`/copyparty remarks:
   * single-sign-on, token-auth, and 2fa is *possible* through authelia/authentik or similar, but nobody's made an example yet
   * one-way folder sync from local to server can be done efficiently with [u2c.py](https://github.com/9001/copyparty/tree/hovudstraum/bin#u2cpy), or with webdav and conventional rsync
   * can hot-reload config files (with just a few exceptions)
@@ -346,21 +346,21 @@ symbol legend,
   * [version-checker](https://github.com/9001/copyparty/#version-checker) can check if the current version has a known vulnerability and immediately exit/shutdown, but automatic self-updating is **not** available
   * [event hooks](https://github.com/9001/copyparty/tree/hovudstraum/bin/hooks) ([discord](https://user-images.githubusercontent.com/241032/215304439-1c1cb3c8-ec6f-4c17-9f27-81f969b1811a.png), [desktop](https://user-images.githubusercontent.com/241032/215335767-9c91ed24-d36e-4b6b-9766-fb95d12d163f.png)) inspired by filebrowser, as well as the more complex [media parser](https://github.com/9001/copyparty/tree/hovudstraum/bin/mtag) alternative
   * upload history can be visualized using [partyjournal](https://github.com/9001/copyparty/blob/hovudstraum/bin/partyjournal.py)
-* `k`/filegator remarks:
+* `fg`/filegator remarks:
   * `per-* permissions` -- can limit a user to one folder and its subfolders
   * `unmap subfolders` -- can globally filter a list of paths
-* `l`/sftpgo:
+* `sg`/sftpgo:
   * `file action event hooks` also include on-download triggers
   * `upload tracking / log` in main logfile
-* `m`/arozos:
+* `az`/arozos:
   * `2fa` maybe possible through LDAP/Oauth
-* `c`/hfs3
+* `h3`/hfs3
   * `2fa` available by installing a plugin
 
 ## client features
 
-| feature / software      |[a]|[b]|[c]|[d]|[e]|[f]|[g]|[h]|[i]|[j]|[k]|[l]|[m]|
-| ----------------------  | - | - | - | - | - | - | - | - | - | - | - | - | - |
+| feature / software      |[cp]|[h2]|[h3]|[nc]|[sf]|[rc]|[df]|[cs]|[kb]|[fb]|[fg]|[sg]|[az]|
+| ----------------------  |:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|
 | single-page app         | █ |   | █ | █ | █ |   |   | █ | █ | █ | █ |   | █ |
 | themes                  | █ | █ | █ | █ |   |   |   |   | █ |   |   |   |   |
 | directory tree nav      | █ | ╱ |   |   | █ |   |   |   | █ |   | ╱ |   |   |
@@ -404,22 +404,22 @@ symbol legend,
 * `search by custom tags` = ability to tag files through the UI and search by those
 * `find local file` = drop a file into the browser to see if it exists on the server
 * `undo recent uploads` = accounts without delete permissions have a time window where they can undo their own uploads
-* `a`/copyparty has teeny-tiny skips playing gapless albums depending on audio codec (opus best)
-* `b`/hfs2 has a very basic directory tree view, not showing sibling folders
-* `f`/rclone can do some file management (mkdir, rename, delete) when hosting througn webdav
-* `j`/filebrowser remarks:
+* `cp`/copyparty has teeny-tiny skips playing gapless albums depending on audio codec (opus best)
+* `h2`/hfs2 has a very basic directory tree view, not showing sibling folders
+* `rc`/rclone can do some file management (mkdir, rename, delete) when hosting througn webdav
+* `fg`/filebrowser remarks:
   * audio playback does not continue into next song
   * plaintext viewer/editor
-* `k`/filegator directory tree is a modal window
-* `l`/sftpgo remarks:
+* `fg`/filegator directory tree is a modal window
+* `sg`/sftpgo remarks:
   * audio/video playback does not continue into next song/video
   * plaintext viewer/editor
 
 
 ## integration
 
-| feature / software      |[a]|[b]|[c]|[d]|[e]|[f]|[g]|[h]|[i]|[j]|[k]|[l]|[m]|
-| ----------------------- | - | - | - | - | - | - | - | - | - | - | - | - | - |
+| feature / software      |[cp]|[h2]|[h3]|[nc]|[sf]|[rc]|[df]|[cs]|[kb]|[fb]|[fg]|[sg]|[az]|
+| ----------------------- |:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|
 | OS alert on upload      | ╱ |   |   |   |   |   |   |   |   | ╱ |   | ╱ |   |
 | discord                 | ╱ |   |   |   |   |   |   |   |   | ╱ |   | ╱ |   |
 | ┗ announce uploads      | ╱ |   |   |   |   |   |   |   |   |   |   | ╱ |   |
@@ -428,11 +428,11 @@ symbol legend,
 | flameshot               |   |   |   |   |   | █ |   |   |   |   |   |   |   |
 
 * sharex `╱` = yes, but does not provide example sharex config
-* `a`/copyparty remarks:
+* `cp`/copyparty remarks:
   * `OS alert on upload` available as [a plugin](https://github.com/9001/copyparty/blob/hovudstraum/bin/hooks/notify.py)
   * `discord » announce uploads` available as [a plugin](https://github.com/9001/copyparty/blob/hovudstraum/bin/hooks/discord-announce.py)
-* `j`/filebrowser can probably pull those off with command runners similar to copyparty
-* `l`/sftpgo has nothing built-in but is very extensible
+* `fg`/filebrowser can probably pull those off with command runners similar to copyparty
+* `sg`/sftpgo has nothing built-in but is very extensible
 
 
 ## another matrix

--- a/docs/versus.md
+++ b/docs/versus.md
@@ -86,7 +86,7 @@ the table headers in the matrixes below are the different softwares, with a quic
 
 the softwares,
 
-[cp]: https://github.com/9001/copyparty "copyparty"
+[C]: https://github.com/9001/copyparty "copyparty"
 [h2]: https://github.com/rejetto/hfs2/ "hfs2"
 [h3]: https://rejetto.com/hfs/ "hfs3"
 [nc]: https://github.com/nextcloud/server "nextcloud"
@@ -100,7 +100,7 @@ the softwares,
 [sg]: https://github.com/drakkan/sftpgo "sftpgo"
 [az]: https://github.com/tobychui/arozos "arozos"
 
-* `cp` = [copyparty][cp]
+* `C` = [copyparty][C]
 * `h2` = [hfs2][h2] 🔥
 * `h3` = [hfs3][h3]
 * `nc` = [nextcloud][nc]
@@ -134,7 +134,7 @@ symbol legend,
 
 ## general
 
-| feature / software      |[cp]|[h2]|[h3]|[nc]|[sf]|[rc]|[df]|[cs]|[kb]|[fb]|[fg]|[sg]|[az]|
+| feature / software      |[C]|[h2]|[h3]|[nc]|[sf]|[rc]|[df]|[cs]|[kb]|[fb]|[fg]|[sg]|[az]|
 | ----------------------- |:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|
 | intuitive UX            |   | ╱ | █ | █ | █ |   | █ | █ | █ | █ | █ | █ | █ |
 | config GUI              |   | █ | █ | █ | █ |   |   | █ | █ | █ |   | █ | █ |
@@ -155,7 +155,7 @@ symbol legend,
 | iOS app                 | ╱ |   |   | █ | █ |   |   |   |   |   |   |   |   |
 
 * `zero setup` = you can get a mostly working setup by just launching the app, without having to install any software or configure whatever
-* `cp`/copyparty remarks:
+* `C`/copyparty remarks:
   * no gui for server settings; only for client-side stuff
   * runs on iOS / iPads using [a-Shell](https://holzschu.github.io/a-Shell_iOS/) (pretty good) or [iSH](https://ish.app/) (very slow) but cannot run in the background and is not able to share all of your phone storage (just a separate dedicated folder)
   * [android app](https://f-droid.org/en/packages/me.ocv.partyup/) is for uploading only
@@ -175,7 +175,7 @@ symbol legend,
 
 *the thing that copyparty is actually kinda good at*
 
-| feature / software      |[cp]|[h2]|[h3]|[nc]|[sf]|[rc]|[df]|[cs]|[kb]|[fb]|[fg]|[sg]|[az]|
+| feature / software      |[C]|[h2]|[h3]|[nc]|[sf]|[rc]|[df]|[cs]|[kb]|[fb]|[fg]|[sg]|[az]|
 | ----------------------- |:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|
 | download folder as zip  | █ | █ | █ | █ | ╱ |   | █ |   | █ | █ | ╱ | █ | ╱ |
 | download folder as tar  | █ |   |   |   |   |   |   |   |   |   |   |   |   |
@@ -224,7 +224,7 @@ symbol legend,
 
 * `cloud storage backend` = able to serve files from (and write to) s3 or similar cloud services; `╱` means the software can do this with some help from `rclone mount` as a bridge
 
-* `cp`/copyparty can reject uploaded files (based on complex conditions), for example [by extension](https://github.com/9001/copyparty/blob/hovudstraum/bin/hooks/reject-extension.py) or [mimetype](https://github.com/9001/copyparty/blob/hovudstraum/bin/hooks/reject-mimetype.py)
+* `C`/copyparty can reject uploaded files (based on complex conditions), for example [by extension](https://github.com/9001/copyparty/blob/hovudstraum/bin/hooks/reject-extension.py) or [mimetype](https://github.com/9001/copyparty/blob/hovudstraum/bin/hooks/reject-mimetype.py)
 * `sf`/seafile download-as-zip is not streaming; it creates the full zipfile before download can start, and fails on big folders
 * `fg`/filebrowser remarks:
   * can provide checksums for single files on request
@@ -239,7 +239,7 @@ symbol legend,
 
 ## protocols and client support
 
-| feature / software      |[cp]|[h2]|[h3]|[nc]|[sf]|[rc]|[df]|[cs]|[kb]|[fb]|[fg]|[sg]|[az]|
+| feature / software      |[C]|[h2]|[h3]|[nc]|[sf]|[rc]|[df]|[cs]|[kb]|[fb]|[fg]|[sg]|[az]|
 | ----------------------- |:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|
 | serve https             | █ |   | █ | █ | █ | █ | █ | █ | █ | █ | █ | █ | █ |
 | serve webdav            | █ |   |   | █ | █ | █ | █ |   | █ |   |   | █ | █ |
@@ -261,7 +261,7 @@ symbol legend,
 * `mojibake filenames` = filenames decoded with the wrong codec and then reencoded (usually to utf-8), so `宇多田ヒカル` might look like `ëFæ╜ôcâqâJâï`
 * `undecodable filenames` = pure binary garbage which cannot be parsed as utf-8
   * you can successfully play `$'\355\221'` with mpv through mounting a remote copyparty server with rclone, pog
-* `cp`/copyparty remarks:
+* `C`/copyparty remarks:
   * extremely minimal samba/cifs server
   * netscape 4 / ie6 support is mostly listed as a joke altho some people have actually found it useful ([ie4 tho](https://user-images.githubusercontent.com/241032/118192791-fb31fe00-b446-11eb-9647-898ea8efc1f7.png))
 * `sg`/sftpgo translates mojibake filenames into valid utf-8 (information loss)
@@ -270,7 +270,7 @@ symbol legend,
 
 ## server configuration
 
-| feature / software      |[cp]|[h2]|[h3]|[nc]|[sf]|[rc]|[df]|[cs]|[kb]|[fb]|[fg]|[sg]|[az]|
+| feature / software      |[C]|[h2]|[h3]|[nc]|[sf]|[rc]|[df]|[cs]|[kb]|[fb]|[fg]|[sg]|[az]|
 | ----------------------- |:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|
 | config from cmd args    | █ |   | █ |   |   | █ | █ |   |   | █ |   | ╱ | ╱ |
 | config files            | █ | █ | █ | ╱ | ╱ | █ |   | █ |   | █ | • | ╱ | ╱ |
@@ -291,7 +291,7 @@ symbol legend,
 
 ## server capabilities
 
-| feature / software      |[cp]|[h2]|[h3]|[nc]|[sf]|[rc]|[df]|[cs]|[kb]|[fb]|[fg]|[sg]|[az]|
+| feature / software      |[C]|[h2]|[h3]|[nc]|[sf]|[rc]|[df]|[cs]|[kb]|[fb]|[fg]|[sg]|[az]|
 | ----------------------- |:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|
 | accounts                | █ | █ | █ | █ | █ | █ | █ | █ | █ | █ | █ | █ | █ |
 | per-account chroot      |   |   |   |   |   |   |   |   |   |   |   | █ |   |
@@ -337,7 +337,7 @@ symbol legend,
 * `speed throttle` = rate limiting (per ip, per user, per connection, anything like that)
 * `curl-friendly ls` = returns a [sortable plaintext folder listing](https://user-images.githubusercontent.com/241032/215322619-ea5fd606-3654-40ad-94ee-2bc058647bb2.png) when curled
 * `curl-friendly upload` = uploading with curl is just `curl -T some.bin http://.../`
-* `cp`/copyparty remarks:
+* `C`/copyparty remarks:
   * single-sign-on, token-auth, and 2fa is *possible* through authelia/authentik or similar, but nobody's made an example yet
   * one-way folder sync from local to server can be done efficiently with [u2c.py](https://github.com/9001/copyparty/tree/hovudstraum/bin#u2cpy), or with webdav and conventional rsync
   * can hot-reload config files (with just a few exceptions)
@@ -359,7 +359,7 @@ symbol legend,
 
 ## client features
 
-| feature / software      |[cp]|[h2]|[h3]|[nc]|[sf]|[rc]|[df]|[cs]|[kb]|[fb]|[fg]|[sg]|[az]|
+| feature / software      |[C]|[h2]|[h3]|[nc]|[sf]|[rc]|[df]|[cs]|[kb]|[fb]|[fg]|[sg]|[az]|
 | ----------------------  |:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|
 | single-page app         | █ |   | █ | █ | █ |   |   | █ | █ | █ | █ |   | █ |
 | themes                  | █ | █ | █ | █ |   |   |   |   | █ |   |   |   |   |
@@ -404,7 +404,7 @@ symbol legend,
 * `search by custom tags` = ability to tag files through the UI and search by those
 * `find local file` = drop a file into the browser to see if it exists on the server
 * `undo recent uploads` = accounts without delete permissions have a time window where they can undo their own uploads
-* `cp`/copyparty has teeny-tiny skips playing gapless albums depending on audio codec (opus best)
+* `C`/copyparty has teeny-tiny skips playing gapless albums depending on audio codec (opus best)
 * `h2`/hfs2 has a very basic directory tree view, not showing sibling folders
 * `rc`/rclone can do some file management (mkdir, rename, delete) when hosting througn webdav
 * `fg`/filebrowser remarks:
@@ -418,7 +418,7 @@ symbol legend,
 
 ## integration
 
-| feature / software      |[cp]|[h2]|[h3]|[nc]|[sf]|[rc]|[df]|[cs]|[kb]|[fb]|[fg]|[sg]|[az]|
+| feature / software      |[C]|[h2]|[h3]|[nc]|[sf]|[rc]|[df]|[cs]|[kb]|[fb]|[fg]|[sg]|[az]|
 | ----------------------- |:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|
 | OS alert on upload      | ╱ |   |   |   |   |   |   |   |   | ╱ |   | ╱ |   |
 | discord                 | ╱ |   |   |   |   |   |   |   |   | ╱ |   | ╱ |   |
@@ -428,7 +428,7 @@ symbol legend,
 | flameshot               |   |   |   |   |   | █ |   |   |   |   |   |   |   |
 
 * sharex `╱` = yes, but does not provide example sharex config
-* `cp`/copyparty remarks:
+* `C`/copyparty remarks:
   * `OS alert on upload` available as [a plugin](https://github.com/9001/copyparty/blob/hovudstraum/bin/hooks/notify.py)
   * `discord » announce uploads` available as [a plugin](https://github.com/9001/copyparty/blob/hovudstraum/bin/hooks/discord-announce.py)
 * `fg`/filebrowser can probably pull those off with command runners similar to copyparty


### PR DESCRIPTION
Currently the tables have a rather poor readability for all the great research put into compiling them (kudos!), requiring keeping a legend around, but just making 2-letter abbreviations makes it way more readable while still keeping the table dense enough (could maybe be split into two columns 1-letter-wide each, but that would break header links

Before: which is NextCloud and RClone?
| feature / software      |a|b|c|d|e|f|g|h|i|j|k|l|m|
| ----------------------- | - | - | - | - | - | - | - | - | - | - | - | - | - |
| runs on FreeBSD         | █ |   | █ | • | █ | █ | █ | • | █ | █ |   | █ |   |

After: well, of course it's NC and RC, why do you ask?
| feature / software      |cp|h2|h3|nc|sf|rc|df|cs|kb|fb|fg|sg|az|
| ----------------------- |:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|
| runs on FreeBSD         | █ |   | █ | • | █ | █ | █ | • | █ | █ |   | █ |   |


This PR complies with the DCO; https://developercertificate.org/  
