### PR TITLE
Update README with share control / restriction (--shr-who)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1005,6 +1005,8 @@ specify `--shr /foobar` to enable this feature; a toplevel virtual folder named 
 
 users can delete their own shares in the controlpanel, and a list of privileged users (`--shr-adm`) are allowed to see and/or delet any share on the server
 
+the volflag `--shr-who` lets you control who can create a share from that volume, either `no` (nobody), `a` (people with admin permission), or `auth` (people who are logged in) 
+
 after a share has expired, it remains visible in the controlpanel for `--shr-rt` minutes (default is 1 day), and the owner can revive it by extending the expiration time there
 
 **security note:** using this feature does not mean that you can skip the [accounts and volumes](#accounts-and-volumes) section -- you still need to restrict access to volumes that you do not intend to share with unauthenticated users! it is not sufficient to use rules in the reverseproxy to restrict access to just the `/share` folder.


### PR DESCRIPTION
added missing volflag argument in documentation, found via [#780](https://github.com/9001/copyparty/issues/780#issuecomment-3269483109)

To show that your contribution is compatible with the MIT License, please include the following text somewhere in this PR description:  
This PR complies with the DCO; https://developercertificate.org/  
