### PR TITLE
Expand default README search

### DIFF
--- a/copyparty/__main__.py
+++ b/copyparty/__main__.py
@@ -1892,7 +1892,7 @@ def add_ui(ap, retry: int):
     ap2.add_argument("--prologues", metavar="T,T", type=u, default=".prologue.html", help="comma-sep. list of filenames to scan for and use as prologues (embed above/before directory listing) (volflag=prologues)")
     ap2.add_argument("--epilogues", metavar="T,T", type=u, default=".epilogue.html", help="comma-sep. list of filenames to scan for and use as epilogues (embed below/after directory listing) (volflag=epilogues)")
     ap2.add_argument("--preadmes", metavar="T,T", type=u, default="preadme.md,PREADME.md", help="comma-sep. list of filenames to scan for and use as preadmes (embed above/before directory listing) (volflag=preadmes)")
-    ap2.add_argument("--readmes", metavar="T,T", type=u, default="readme.md,README.md", help="comma-sep. list of filenames to scan for and use as readmes (embed below/after directory listing) (volflag=readmes)")
+    ap2.add_argument("--readmes", metavar="T,T", type=u, default="readme.md,README.md,readme.txt,README.txt,README", help="comma-sep. list of filenames to scan for and use as readmes (embed below/after directory listing) (volflag=readmes)")
     ap2.add_argument("--doctitle", metavar="TXT", type=u, default="copyparty @ --name", help="title / service-name to show in html documents")
     ap2.add_argument("--bname", metavar="TXT", type=u, default="--name", help="server name (displayed in filebrowser document title)")
     ap2.add_argument("--pb-url", metavar="URL", type=u, default=URL_PRJ, help="powered-by link; disable with \033[33m-nb\033[0m")

--- a/copyparty/cfg.py
+++ b/copyparty/cfg.py
@@ -352,7 +352,7 @@ flagcats = {
         "unlistcw": "don't list write-access in controlpanel",
         "prologues=.prologue.html": "files to embed above/before files",
         "epilogues=.epilogue.html": "files to embed below/after files",
-        "readmes=readme.md,README.md": "files to embed as readmes",
+        "readmes=readme.md,README.md,readme.txt,README.txt,README": "files to embed as readmes",
         "preadmes=preadme.md,PREADME.md": "files to embed as preadmes",
         "no_sb_md": "disable js sandbox for markdown files",
         "no_sb_lg": "disable js sandbox for prologue/epilogue",

--- a/copyparty/util.py
+++ b/copyparty/util.py
@@ -594,7 +594,16 @@ UNHUMANIZE_UNITS = {
 
 VF_CAREFUL = {"mv_re_t": 5, "rm_re_t": 5, "mv_re_r": 0.1, "rm_re_r": 0.1}
 
-FN_EMB = set([".prologue.html", ".epilogue.html", "readme.md", "preadme.md"])
+FN_EMB = set(
+    [
+        ".prologue.html",
+        ".epilogue.html",
+        "readme.md",
+        "preadme.md",
+        "readme.txt",
+        "readme",
+    ]
+)
 
 
 def read_ram() -> tuple[float, float]:


### PR DESCRIPTION
Expand the default README search list because `README.txt` and `README` are common in older projects and I was quite surprised they didn't get automatically served in directory listings by default.

I explicitly did not include `preadmes` since I don't think it's a standard outside copyparty.

This PR complies with the DCO; https://developercertificate.org/  
