### PR TITLE
Adding new flag for optional calculation of Volumes created at the root

### DIFF
--- a/copyparty/__main__.py
+++ b/copyparty/__main__.py
@@ -1794,6 +1794,7 @@ def add_db_general(ap, hcores):
     ap2.add_argument("--no-idx", metavar="PTN", type=u, default=noidx, help="regex: disable indexing of matching absolute-filesystem-paths during e2ds folder scan (must be specified as one big regex, not multiple times) (volflag=noidx)")
     ap2.add_argument("--no-dirsz", action="store_true", help="do not show total recursive size of folders in listings, show inode size instead; slightly faster (volflag=nodirsz)")
     ap2.add_argument("--re-dirsz", action="store_true", help="if the directory-sizes in the UI are bonkers, use this along with \033[33m-e2dsa\033[0m to rebuild the index from scratch")
+    ap2.add_argument("--deep-dirsz", action="store_true", help="show correct sizes for child volumes in parent listings (possible drain on performance)")
     ap2.add_argument("--no-dhash", action="store_true", help="disable rescan acceleration; do full database integrity check -- makes the db ~5%% smaller and bootup/rescans 3~10x slower")
     ap2.add_argument("--re-dhash", action="store_true", help="force a cache rebuild on startup; enable this once if it gets out of sync (should never be necessary)")
     ap2.add_argument("--no-forget", action="store_true", help="never forget indexed files, even when deleted from disk -- makes it impossible to ever upload the same file twice -- only useful for offloading uploads to a cloud service or something (volflag=noforget)")

--- a/copyparty/httpcli.py
+++ b/copyparty/httpcli.py
@@ -7375,9 +7375,17 @@ class HttpCli(object):
                 for fe in dirs:
                     try:
                         hit = icur.execute(q, (vdir + fe["name"],)).fetchone()
-                        (fe["sz"], fe["tags"][".files"]) = hit
+                        if not hit and self.args.deep_dirsz:
+                            child_rp = os.path.join(abspath, fe["name"])
+                            hit = self.conn.hsrv.broker.ask(
+                                "up2k.get_volrootsize", child_rp
+                            ).get()
+                            if hit == (0, 0):
+                                hit = None
+                        if hit:
+                            (fe["sz"], fe["tags"][".files"]) = hit
                     except:
-                        pass  # 404 or mojibake
+                        pass # 404 or mojibake
 
             taglist = [k for k in lmte if k in tagset]
         else:

--- a/copyparty/up2k.py
+++ b/copyparty/up2k.py
@@ -528,6 +528,13 @@ class Up2k(object):
 
         return (nbytes, nfiles)
 
+    def get_volrootsize(self, realpath: str) -> tuple[int, int]:
+        cur = self.cur.get(realpath)
+        if not cur:
+            return (0, 0)
+        hit = cur.execute("select sz, nf from ds where rd='' limit 1").fetchone()
+        return hit if hit else (0, 0)
+
     def rescan(
         self, all_vols: dict[str, VFS], scan_vols: list[str], wait: bool, fscan: bool
     ) -> str:


### PR DESCRIPTION
Adding this as a potential fix for https://github.com/9001/copyparty/issues/1033

The block of code I changed in httpcli should now query into the volumes at the root and fetch their sizes, this shouldn't effect anything else, as its blocked behind an optional flag for "deep" searching the directory sizes. (deep-dirsz)

before it would pass over since the database excludes the config defined volumes from indexing, this just adds an extra check if the result was falsey / none, AND if the user actually wants to see the sizes


(I've never made a pr to a repo that wasn't just me and my friends / classmates in college sorry if something is wrong)


This PR complies with the DCO; https://developercertificate.org/