### PR TITLE
fix playlist error on re-sorted filelists

### DIFF
--- a/copyparty/web/browser.js
+++ b/copyparty/web/browser.js
@@ -1719,9 +1719,9 @@ function MPlayer() {
 			if (!tid || tid.indexOf('af-') !== 0)
 				continue;
 
-			var trackid = tid.slice(1);
-			if (r.tracks[trackid]) 
-				order.push(trackid);
+			tid = tid.slice(1);
+			if (r.tracks[tid]) 
+				order.push(tid);
 		}
 		r.order = order;
 		r.shuffle();

--- a/copyparty/web/browser.js
+++ b/copyparty/web/browser.js
@@ -1719,7 +1719,9 @@ function MPlayer() {
 			if (!tid || tid.indexOf('af-') !== 0)
 				continue;
 
-			order.push(tid.slice(1));
+			var trackid = tid.slice(1);
+			if (r.tracks[trackid]) 
+				order.push(trackid);
 		}
 		r.order = order;
 		r.shuffle();


### PR DESCRIPTION
normally playlist files are skipped when building the playback order; however, if the filelist is reordered or shuffle is enabled or disabled without reloading the page, the new playback order will include any playlist files on the filelist. so we add a check that ensures the reordered playback list doesn't add anything that wasn't there before the reordering.

fixes #1396 

This PR complies with the DCO; https://developercertificate.org/  
