### PR TITLE
Add automatic browser locale detection using `--glang`

### DIFF
--- a/copyparty/__main__.py
+++ b/copyparty/__main__.py
@@ -1870,6 +1870,7 @@ def add_ui(ap, retry: int):
     ap2.add_argument("--ui-filesz", metavar="FMT", type=u, default="1", help="default filesize format; one of these: 0, 1, 2, 2c, 3, 3c, 4, 4c, 5, 5c, fuzzy (see UI)")
     ap2.add_argument("--rcm", metavar="TXT", default="yy", help="rightclick-menu; two yes/no options: 1st y/n is enable-custom-menu, 2nd y/n is enable-double")
     ap2.add_argument("--lang", metavar="LANG", type=u, default="eng", help="language, for example \033[32meng\033[0m / \033[32mnor\033[0m / ...")
+    ap2.add_argument("--glang", action="store_true", help="guess the browser's default language, otherwise fall back to \033[33m--lang\033[0m")
     ap2.add_argument("--theme", metavar="NUM", type=int, default=0, help="default theme to use (0..%d)" % (THEMES - 1,))
     ap2.add_argument("--themes", metavar="NUM", type=int, default=THEMES, help="number of themes installed")
     ap2.add_argument("--au-vol", metavar="0-100", type=int, default=50, choices=range(0, 101), help="default audio/video volume percent")

--- a/copyparty/authsrv.py
+++ b/copyparty/authsrv.py
@@ -3268,6 +3268,7 @@ class AuthSrv(object):
                 "frand": bool(vf.get("rand")),
                 "lifetime": vn.js_ls["lifetime"],
                 "u2sort": self.args.u2sort,
+                "glang": self.args.glang
             }
             zs = "ui_noacci ui_nocpla ui_noctxb ui_nolbar ui_nombar ui_nonav ui_notree ui_norepl ui_nosrvi"
             for zs in zs.split():

--- a/copyparty/authsrv.py
+++ b/copyparty/authsrv.py
@@ -3268,13 +3268,12 @@ class AuthSrv(object):
                 "frand": bool(vf.get("rand")),
                 "lifetime": vn.js_ls["lifetime"],
                 "u2sort": self.args.u2sort,
-                "glang": self.args.glang
             }
             zs = "ui_noacci ui_nocpla ui_noctxb ui_nolbar ui_nombar ui_nonav ui_notree ui_norepl ui_nosrvi"
             for zs in zs.split():
                 if vf.get(zs):
                     js_htm[zs] = 1
-            zs = "notooltips"
+            zs = "glang notooltips"
             for zs in zs.split():
                 if getattr(self.args, zs, False):
                     js_htm[zs] = 1

--- a/copyparty/web/browser.js
+++ b/copyparty/web/browser.js
@@ -713,6 +713,54 @@ var L = Ls[lang] || Ls.eng, LANGS = [];
 for (var a = 0; a < LANGN.length; a++)
 	LANGS.push(LANGN[a][0]);
 
+if (window.glang && navigator.languages && !/\bcplng=/.test(document.cookie))
+	(function() {
+		var lmap = [
+			["eng", /^en/i],
+			["nor", /^n[ob]/i],
+			["chi", /^zh-cn/i],
+			["cze", /^cs/i],
+			["deu", /^de/i],
+			["epo", /^eo/i],
+			["fin", /^fi/i],
+			["fra", /^fr/i],
+			["grc", /^el/i],
+			["hun", /^hu/i],
+			["ita", /^it/i],
+			["jpn", /^ja/i],
+			["kor", /^ko/i],
+			["nld", /^nl/i],
+			["nno", /^nn/i],
+			["pol", /^pl/i],
+			["por", /^pt/i],
+			["rus", /^ru/i],
+			["spa", /^es/i],
+			["swe", /^sv/i],
+			["tur", /^tr/i],
+			["ukr", /^uk/i],
+			["vie", /^vi/i],
+		];
+		for (var a = 0; a < navigator.languages.length; a++) {
+			for (var b = 0; b < lmap.length; b++) {
+				var n = lmap[b][0];
+				if (!lmap[b][1].test(navigator.languages[a]) || !has(LANGS, n))
+					continue;
+
+				if (Ls[n]) {
+					lang = n;
+					L = Ls[n];
+					return;
+				}
+				if (window.stop)
+					window.stop();
+				document.body.innerHTML = 'Loading ' + n;
+				setck("cplng=" + n, location.reload.bind(location));
+				crashed = true;
+				throw 1;
+			}
+		}
+	})();
+
 
 function langtest() {
 	var n = LANGS.length - 1;
@@ -8496,43 +8544,6 @@ var setfszf = (function () {
 	}
 
 	freshen();
-
-	let lmap = [
-		["eng", /^en(-.+)?$/],
-		["nor", /^(no|nb)$/],
-		["chi", /^zh(-.+)?$/],
-		["cze", /^cs$/],
-		["deu", /^de(-.+)?$/],
-		["epo", /^eo$/],
-		["fin", /^fi$/],
-		["fra", /^fr(-.+)?$/],
-		["grc", /^el$/],
-		["hu", /^hu$/],
-		["ita", /^it(-ch)?$/],
-		["jpn", /^ja$/],
-		["kor", /^ko(-.+)?$/],
-		["nl", /^nl(-be)?$/],
-		["nyn", /^nn$/],
-		["pol", /^pl$/],
-		["por", /^pt(-.+)?$/],
-		["rus", /^ru(-md)?$/],
-		["spa", /^es(-.+)?$/],
-		["swe", /^sv(-.+)?$/],
-		["tur", /^tr$/],
-		["ukr", /^uk$/],
-		["vie", /^vi$/]
-	];
-	
-	if (glang && navigator.languages && !/(^|; )cplng=/.test(document.cookie)) {
-		for (let i = 0; i < navigator.languages.length; i++) {
-			for (let j = 0; j < lmap.length; j++) {
-				console.log(lmap[j]);
-				if (lmap[j][1].test(navigator.languages[i])) {
-					return setck('cplng=' + lmap[j][0], location.reload.bind(location));
-				}
-			}
-		}
-	}
 })();
 
 

--- a/copyparty/web/browser.js
+++ b/copyparty/web/browser.js
@@ -8496,6 +8496,43 @@ var setfszf = (function () {
 	}
 
 	freshen();
+
+	let lmap = [
+		["eng", /^en(-.+)?$/],
+		["nor", /^(no|nb)$/],
+		["chi", /^zh(-.+)?$/],
+		["cze", /^cs$/],
+		["deu", /^de(-.+)?$/],
+		["epo", /^eo$/],
+		["fin", /^fi$/],
+		["fra", /^fr(-.+)?$/],
+		["grc", /^el$/],
+		["hu", /^hu$/],
+		["ita", /^it(-ch)?$/],
+		["jpn", /^ja$/],
+		["kor", /^ko(-.+)?$/],
+		["nl", /^nl(-be)?$/],
+		["nyn", /^nn$/],
+		["pol", /^pl$/],
+		["por", /^pt(-.+)?$/],
+		["rus", /^ru(-md)?$/],
+		["spa", /^es(-.+)?$/],
+		["swe", /^sv(-.+)?$/],
+		["tur", /^tr$/],
+		["ukr", /^uk$/],
+		["vie", /^vi$/]
+	];
+	
+	if (glang && navigator.languages && !/(^|; )cplng=/.test(document.cookie)) {
+		for (let i = 0; i < navigator.languages.length; i++) {
+			for (let j = 0; j < lmap.length; j++) {
+				console.log(lmap[j]);
+				if (lmap[j][1].test(navigator.languages[i])) {
+					return setck('cplng=' + lmap[j][0], location.reload.bind(location));
+				}
+			}
+		}
+	}
 })();
 
 


### PR DESCRIPTION
This adds an automatic browser locale detection that can be enabled with the `--glang` flag. Locales are detected using the `navigator.languages` field in JS. If it can't find a fitting language, it falls back to the default one specified by `--lang`.

(This PR complies with the DCO; https://developercertificate.org/)
