### PR TITLE
chore: improve responsivity on small screens

### DIFF
--- a/copyparty/web/browser.css
+++ b/copyparty/web/browser.css
@@ -3231,14 +3231,40 @@ html.d #treepar {
 
 
 
+@media (max-width: 28em) {
+	#u2conf {
+		font-size: .8em;
+	}
+}
 @media (max-width: 32em) {
 	#u2conf {
 		font-size: .9em;
 	}
 }
-@media (max-width: 28em) {
-	#u2conf {
-		font-size: .8em;
+@media (max-width: 35em) {
+	#wrap {
+		flex: 1 1 auto;
+		min-height: 0;
+		overflow-y: auto;
+		overscroll-behavior-y: contain;
+		-webkit-overflow-scrolling: touch;
+	}
+	#wtoggle {
+		left: 0;
+		right: 0;
+		height: auto;
+		min-height: 1em;
+		overflow-x: auto;
+		overflow-y: hidden;
+		-webkit-overflow-scrolling: touch;
+		touch-action: pan-x;
+		scrollbar-gutter: stable;
+		border-radius: 0;
+		padding-left: 0;
+		padding-bottom: .35em;
+	}
+	#wtoggle>* {
+		flex: 0 0 auto;
 	}
 }
 @media (min-width: 70em) {

--- a/copyparty/web/browser.js
+++ b/copyparty/web/browser.js
@@ -1768,7 +1768,7 @@ function MPlayer() {
 				continue;
 
 			tid = tid.slice(1);
-			if (r.tracks[tid]) 
+			if (r.tracks[tid])
 				order.push(tid);
 		}
 		r.order = order;
@@ -6854,7 +6854,7 @@ function aligngriditems() {
 	if (((griditemcount * em2px) * gridsz) + totalgapwidth < gridwidth) {
 		val = 'left';
 	} else {
-		val = treectl.hidden ? 'center' : 'space-between';
+		val = treectl.hidden ? 'center' : 'space-evenly';
 	}
 	if (st.justifyContent != val)
 		st.justifyContent = val;
@@ -9938,19 +9938,19 @@ function reload_browser() {
 	var selbox = null;
 	var ttimer = null;
 
-	var lpdelay = 250; 
+	var lpdelay = 250;
 	var mvthresh = 44;
 
 	function unbox() {
 		qsr('.selbox');
 		ebi('gfiles').style.removeProperty('pointer-events')
 		ebi('wrap').style.removeProperty('user-select')
-		
+
 		if (selbox) {
 			console.log(selbox)
 			window.getSelection().removeAllRanges();
 		}
-		
+
 		is_selma = false;
 		dragging = false;
 		fwrap = null;
@@ -9993,7 +9993,7 @@ function reload_browser() {
 		starty = pos.y;
 		is_selma = true;
 		ttimer = null;
-		
+
 		if (e.type === 'touchstart') {
 			ttimer = setTimeout(function() {
 				ttimer = null;
@@ -10001,7 +10001,7 @@ function reload_browser() {
 			}, lpdelay);
 		}
 	}
-	
+
 	function start_drag() {
 		if (dragging) return;
 
@@ -10012,7 +10012,7 @@ function reload_browser() {
 
 		ebi('gfiles').style.pointerEvents = 'none';
 	}
-	
+
 	function sel_move(e) {
 		if (!is_selma) return;
 		var pos = getpp(e);
@@ -10027,7 +10027,7 @@ function reload_browser() {
 			return;
 		}
 		if (!dragging && dist > mvthresh && !window.getSelection().toString()) {
-			if (fwrap = e.target.closest('#wrap')) 
+			if (fwrap = e.target.closest('#wrap'))
 				fwrap.style.userSelect = 'none';
 			else return;
 			start_drag();
@@ -10075,7 +10075,7 @@ function reload_browser() {
 			}
 		});
 	}
-	
+
 	dsel_init();
 })();
 
@@ -10118,7 +10118,7 @@ var mpss = (function() {
 
 		var gain = afilt.ssg.gain;
 		var duration = ae.duration || 0;
-	
+
 		var slimit = duration * (config.sthresh / 100);
 		var elimit = duration * (1 - (config.etresh / 100));
 		var in_limits = ae.currentTime < slimit || ae.currentTime > elimit;


### PR DESCRIPTION
On a small screen, the wToggle can be hidden at the edge. This PR adds a full-width, scrollable wToggle for convenience.

<img width="944" height="1842" alt="image" src="https://github.com/user-attachments/assets/6820ae59-64dc-4a51-af8a-22c47da6b7c0" />

And the menu is also full width on a small screen, making navigation more accessible on a horizontally constrained display. The file explorer is hidden, as it was unusable anyway. This allows the user to focus on either finding a directory or viewing the files.

Signed-off-by: William Phetsinorath <william.phetsinorath@shikanime.studio>

To show that your contribution is compatible with the MIT License, please include the following text somewhere in this PR description:  
This PR complies with the DCO; https://developercertificate.org/  
