### PR TITLE
Greater compatibility for *BSD

### DIFF
--- a/copyparty/__init__.py
+++ b/copyparty/__init__.py
@@ -44,6 +44,14 @@ ANYWIN = WINDOWS or sys.platform in ["msys", "cygwin"]
 
 MACOS = platform.system() == "Darwin"
 
+FREEBSD = platform.system() == "FreeBSD"
+
+OPENBSD = platform.system() == "OpenBSD"
+
+ANYBSD = FREEBSD or OPENBSD
+
+UNIX = MACOS or ANYBSD
+
 GRAAL = platform.python_implementation() == "GraalVM"
 
 EXE = bool(getattr(sys, "frozen", False))

--- a/copyparty/fsutil.py
+++ b/copyparty/fsutil.py
@@ -7,7 +7,7 @@ import os
 import re
 import time
 
-from .__init__ import ANYWIN, MACOS
+from .__init__ import ANYWIN, FREEBSD, MACOS, UNIX
 from .authsrv import AXS, VFS, AuthSrv
 from .bos import bos
 from .util import chkcmd, json_hesc, min_ex, undot
@@ -88,7 +88,7 @@ class Fstab(object):
 
     def _from_sp_mount(self) -> dict[str, str]:
         sptn = r"^.*? on (.*) type ([^ ]+) \(.*"
-        if MACOS:
+        if MACOS or FREEBSD:
             sptn = r"^.*? on (.*) \(([^ ]+), .*"
 
         ptn = re.compile(sptn)
@@ -118,7 +118,7 @@ class Fstab(object):
 
     def build_tab(self) -> None:
         self.log("inspecting mtab for changes")
-        dtab = self._from_sp_mount() if MACOS else self._from_proc()
+        dtab = self._from_sp_mount() if UNIX else self._from_proc()
 
         # keep empirically-correct values if mounttab unchanged
         srctab = str(sorted(dtab.items()))
@@ -130,7 +130,7 @@ class Fstab(object):
 
         try:
             fuses = [mp for mp, fs in dtab.items() if fs == "fuseblk"]
-            if not fuses or MACOS:
+            if not fuses or UNIX:
                 raise Exception()
             try:
                 so, _ = chkcmd(["lsblk", "-nrfo", "FSTYPE,MOUNTPOINT"])  # centos6

--- a/copyparty/tcpsrv.py
+++ b/copyparty/tcpsrv.py
@@ -7,7 +7,7 @@ import socket
 import sys
 import time
 
-from .__init__ import ANYWIN, PY2, TYPE_CHECKING, unicode
+from .__init__ import ANYWIN, OPENBSD, PY2, TYPE_CHECKING, UNIX, unicode
 from .cert import gencert
 from .qrkode import QrCode, qr2png, qr2svg, qr2txt, qrgen
 from .util import (
@@ -510,12 +510,19 @@ class TcpSrv(object):
         return eps
 
     def _extdevs_nix(self) -> Generator[str, None, None]:
-        with open("/proc/net/route", "rb") as f:
-            next(f)
-            for ln in f:
-                r = ln.decode("utf-8").strip().split()
-                if r[1] == "0" * 8 and int(r[3], 16) & 2:
-                    yield r[0]
+        if UNIX:
+            so, _ = chkcmd(["netstat", "-nrf", "inet"])
+            for ln in so.split("\n"):
+                if not ln.startswith("default"):
+                    continue
+                yield ln.split()[7] if OPENBSD else ln.split()[3]
+        else:
+            with open("/proc/net/route", "rb") as f:
+                next(f)
+                for ln in f:
+                    r = ln.decode("utf-8").strip().split()
+                    if r[1] == "0" * 8 and int(r[3], 16) & 2:
+                        yield r[0]
 
     def _defroute(self) -> str:
         ret = ""

--- a/copyparty/tcpsrv.py
+++ b/copyparty/tcpsrv.py
@@ -516,13 +516,13 @@ class TcpSrv(object):
                 if not ln.startswith("default"):
                     continue
                 yield ln.split()[7] if OPENBSD else ln.split()[3]
-        else:
-            with open("/proc/net/route", "rb") as f:
-                next(f)
-                for ln in f:
-                    r = ln.decode("utf-8").strip().split()
-                    if r[1] == "0" * 8 and int(r[3], 16) & 2:
-                        yield r[0]
+            return
+        with open("/proc/net/route", "rb") as f:
+            next(f)
+            for ln in f:
+                r = ln.decode("utf-8").strip().split()
+                if r[1] == "0" * 8 and int(r[3], 16) & 2:
+                    yield r[0]
 
     def _defroute(self) -> str:
         ret = ""


### PR DESCRIPTION
There are references to `lsblk` (from util-linux) and /proc that don't exist on *BSD, so this expands on some macOS-specific code to compensate for that

I did my best to follow the existing style and structure of the code, however I might have missed something (and also given that `_extdevs_nix()` doesn't show IPv6 addresses by default that might need to be reworked in the future anyway)

Testing from OpenBSD and FreeBSD users more than welcome, I have thus far tested this briefly on my OpenBSD box

This also lays better groundwork for packaging on OpenBSD and FreeBSD which I will get to afterwards

This PR complies with the DCO; https://developercertificate.org/  
