### PR TITLE
make `.txt` the default extension for `text/plain`

### DIFF
--- a/copyparty/util.py
+++ b/copyparty/util.py
@@ -491,13 +491,12 @@ font woff woff2 otf ttf
         for v in vs.strip().split():
             MIMES[v] = "{}/{}".format(k, v)
 
-    for ln in """text md=plain txt=plain js=javascript
+    for ln in """text md=plain js=javascript ass=plain ssa=plain txt=plain
 application 7z=x-7z-compressed tar=x-tar bz2=x-bzip2 gz=gzip rar=x-rar-compressed zst=zstd xz=x-xz lz=lzip cpio=x-cpio
 application msi=x-ms-installer cab=vnd.ms-cab-compressed rpm=x-rpm crx=x-chrome-extension
 application epub=epub+zip mobi=x-mobipocket-ebook lit=x-ms-reader rss=rss+xml atom=atom+xml torrent=x-bittorrent
 application p7s=pkcs7-signature dcm=dicom shx=vnd.shx shp=vnd.shp dbf=x-dbf gml=gml+xml gpx=gpx+xml amf=x-amf
 application swf=x-shockwave-flash m3u=vnd.apple.mpegurl db3=vnd.sqlite3 sqlite=vnd.sqlite3
-text ass=plain ssa=plain
 image jpg=jpeg xpm=x-xpixmap psd=vnd.adobe.photoshop jpf=jpx tif=tiff ico=x-icon djvu=vnd.djvu
 image heics=heic-sequence heifs=heif-sequence hdr=vnd.radiance svg=svg+xml
 image arw=x-sony-arw cr2=x-canon-cr2 crw=x-canon-crw dcr=x-kodak-dcr dng=x-adobe-dng erf=x-epson-erf


### PR DESCRIPTION
Closes #1427 

`MIMES.items()` iterates in insertion order, so the last-inserted entry had priority, meaning that `text/plain` got `ssa` as default extension.


This PR complies with the DCO; https://developercertificate.org/  
