### PR TITLE
Better ipv6 ratelimiting logic

### DIFF
--- a/copyparty/util.py
+++ b/copyparty/util.py
@@ -1500,9 +1500,7 @@ class Garda(object):
         if not self.lim:
             return 0, ip
 
-        if ":" in ip:
-            # assume /64 clients; drop 4 groups
-            ip = IPv6Address(ip).exploded[:-20]
+        ip = ipnorm(ip)
 
         if prev and self.uniq:
             if self.prev.get(ip) == prev:
@@ -2445,8 +2443,8 @@ def odfusion(
 
 def ipnorm(ip: str) -> str:
     if ":" in ip:
-        # assume /64 clients; drop 4 groups
-        return IPv6Address(ip).exploded[:-20]
+        # assume /56 clients; drop 4 groups
+        return str(IPv6Network(ip + "/56", strict=False).network_address)
 
     return ip
 

--- a/copyparty/util.py
+++ b/copyparty/util.py
@@ -1500,7 +1500,8 @@ class Garda(object):
         if not self.lim:
             return 0, ip
 
-        ip = ipnorm(ip)
+        if ":" in ip:
+            ip = ipnorm(ip)
 
         if prev and self.uniq:
             if self.prev.get(ip) == prev:

--- a/copyparty/util.py
+++ b/copyparty/util.py
@@ -2443,7 +2443,7 @@ def odfusion(
 
 def ipnorm(ip: str) -> str:
     if ":" in ip:
-        # assume /56 clients; drop 4 groups
+        # assume /56 clients; drop final 72 bits
         return str(IPv6Network(ip + "/56", strict=False).network_address)
 
     return ip


### PR DESCRIPTION
This is a simple change that also allows for configuration of the truncated prefix length later. I changed it to /56 because that is the recommended prefix length for residential networks.

This PR complies with the DCO; https://developercertificate.org/  
