### PR TITLE
fix rcm related errors

### DIFF
--- a/copyparty/web/browser.js
+++ b/copyparty/web/browser.js
@@ -5740,7 +5740,11 @@ var thegrid = (function () {
 		var ths = QSA('#ggrid>a');
 
 		for (var a = 0, aa = ths.length; a < aa; a++) {
-			var tr = ebi(ths[a].getAttribute('ref')).closest('tr'),
+			var ref = ths[a].getAttribute('ref');
+			if (!ref)
+				continue;
+			var reft = ebi(ref);
+			var tr = reft && reft.closest('tr'),
 				cl = tr.className || '';
 
 			if (noq_href(ths[a]).endsWith('/'))

--- a/copyparty/web/browser.js
+++ b/copyparty/web/browser.js
@@ -5743,9 +5743,7 @@ var thegrid = (function () {
 			var ref = ths[a].getAttribute('ref');
 			if (!ref)
 				continue;
-			var reft = ebi(ref);
-			var tr = reft && reft.closest('tr'),
-				cl = tr.className || '';
+			var cl = ebi(ref).closest('tr').className || '';
 
 			if (noq_href(ths[a]).endsWith('/'))
 				cl += ' dir';
@@ -6273,6 +6271,9 @@ var ahotkeys = function (e) {
 		if (thegrid.en)
 			return ebi('griden').click();
 	}
+
+	if (aet == 'input')
+		return;
 
 	var in_ftab = (aet == 'tr' || aet == 'td') && ae.closest('#files');
 	if (in_ftab) {


### PR DESCRIPTION
tl;dr: the ebi in `loadsel` returns null sometimes for various reasons and trying to call closest('tr') on said null leads to an error in a few cases:
- rcm: right click any file and click 'new file' or 'new folder' (grid only)
- rcm/dsel: use rcm to create new file/folder in empty dir and start dragging box from on top of (not yet actually existing) dir/file (also grid only due to dsel)
- rcm/hotkeys: use rcm to create new file/folder, press ctrl+a before giving it a name (you know it)

so let's add some checks to ensure we don't call .closest('tr') on nulls.

fixes #1330 #1362 

To show that your contribution is compatible with the MIT License, please include the following text somewhere in this PR description:  
This PR complies with the DCO; https://developercertificate.org/  
