### PR TITLE
Add macOS related information

### DIFF
--- a/README.md
+++ b/README.md
@@ -2321,9 +2321,7 @@ if you want to change the fonts, see [./docs/rice/](./docs/rice/)
 
 become a *real* webserver  which people can access by just going to your IP or domain without specifying a port
 
-**if you're on windows,** then you just need to add the commandline argument `-p 80,443` and you're done! nice
-
-**if you're on macos,** sorry, I don't know
+**if you're on windows or macos,** then you just need to add the commandline argument `-p 80,443` and you're done! nice
 
 **if you're on Linux,** you have the following 4 options:
 

--- a/docs/devnotes.md
+++ b/docs/devnotes.md
@@ -447,6 +447,12 @@ build the sfx using any of the following examples:
 ./scripts/make-sfx.sh gz no-cm  # gzip-compressed + no fancy markdown editor
 ```
 
+on macos, you need to download several GNU utilities before building:
+
+```zsh
+brew install gsed gnu-tar findutils coreutils
+```
+
 
 ## build from release tarball
 


### PR DESCRIPTION
This PR adds macOS-related information to the README and devnotes.

* It appears that assigning ports 80 and 443 works without requiring root permissions, at least on macOS 26 Tahoe what I tested, so I updated the README accordingly.
* Adds information on how to install the GNU utilities required to build the sfx on macOS.

This PR complies with the DCO; [developercertificate.org](https://developercertificate.org/)