### PR TITLE
improve opds compatibility

### DIFF
--- a/copyparty/httpcli.py
+++ b/copyparty/httpcli.py
@@ -7186,12 +7186,11 @@ class HttpCli(object):
         dirs = []
         files = []
         ptn_hr = RE_HR
-        use_abs_url = (
-            not is_opds
+        use_abs_url = is_opds or (
+            vpath
             and not is_ls
             and not is_js
             and not self.trailing_slash
-            and vpath
         )
         for fn in ls_names:
             base = ""
@@ -7527,17 +7526,20 @@ class HttpCli(object):
                 ]
 
             j2a["opds_osd"] = "%s%s?opds&osd" % (self.args.SRS, quotep(vpath))
-
+            j2a["opds_id"] = uuid.uuid5(uuid.NAMESPACE_URL, vpath + "/").urn
+            j2a["opds_title"] = (vpath.rsplit("/", 1)[-1] + '/') if vpath else self.args.bname
             for item in dirs:
                 href = item["href"]
                 href += ("&" if "?" in href else "?") + "opds"
                 item["href"] = href
+                item["opds_id"] = uuid.uuid5(uuid.NAMESPACE_URL, "%s/%s" % (vpath, item["name"])).urn
                 item["iso8601"] = "%sZ" % (item["dt"].replace(" ", "T"),)
 
             for item in files:
                 href = item["href"]
                 href += ("&" if "?" in href else "?") + "dl"
                 item["href"] = href
+                item["opds_id"] = uuid.uuid5(uuid.NAMESPACE_URL, "%s/%s" % (vpath, item["name"])).urn
                 item["iso8601"] = "%sZ" % (item["dt"].replace(" ", "T"),)
 
                 if "rmagic" in self.vn.flags:

--- a/copyparty/httpcli.py
+++ b/copyparty/httpcli.py
@@ -7187,18 +7187,18 @@ class HttpCli(object):
         files = []
         ptn_hr = RE_HR
         use_abs_url = is_opds or (
-            vpath
-            and not is_ls
-            and not is_js
-            and not self.trailing_slash
+            vpath and not is_ls and not is_js and not self.trailing_slash
         )
         for fn in ls_names:
             base = ""
             href = fn
             if use_abs_url:
-                base = self.args.SRS
-                if vpath:
-                    base += vpath + "/"
+                if is_opds:
+                    base = self.args.SRS
+                    if vpath:
+                        base += vpath + "/"
+                else:
+                    base = "/" + vpath + "/"
                 href = base + fn
 
             if fn in vfs_virt:
@@ -7529,19 +7529,25 @@ class HttpCli(object):
 
             j2a["opds_osd"] = "%s%s?opds&osd" % (self.args.SRS, quotep(vpath))
             j2a["opds_id"] = uuid.uuid5(uuid.NAMESPACE_URL, vpath + "/").urn
-            j2a["opds_title"] = (vpath.rsplit("/", 1)[-1] + '/') if vpath else self.args.bname
+            j2a["opds_title"] = (
+                (vpath.rsplit("/", 1)[-1] + "/") if vpath else self.args.bname
+            )
             for item in dirs:
                 href = item["href"]
                 href += ("&" if "?" in href else "?") + "opds"
                 item["href"] = href
-                item["opds_id"] = uuid.uuid5(uuid.NAMESPACE_URL, "%s/%s" % (vpath, item["name"])).urn
+                item["opds_id"] = uuid.uuid5(
+                    uuid.NAMESPACE_URL, "%s/%s" % (vpath, item["name"])
+                ).urn
                 item["iso8601"] = "%sZ" % (item["dt"].replace(" ", "T"),)
 
             for item in files:
                 href = item["href"]
                 href += ("&" if "?" in href else "?") + "dl"
                 item["href"] = href
-                item["opds_id"] = uuid.uuid5(uuid.NAMESPACE_URL, "%s/%s" % (vpath, item["name"])).urn
+                item["opds_id"] = uuid.uuid5(
+                    uuid.NAMESPACE_URL, "%s/%s" % (vpath, item["name"])
+                ).urn
                 item["iso8601"] = "%sZ" % (item["dt"].replace(" ", "T"),)
 
                 if "rmagic" in self.vn.flags:

--- a/copyparty/httpcli.py
+++ b/copyparty/httpcli.py
@@ -7196,7 +7196,9 @@ class HttpCli(object):
             base = ""
             href = fn
             if use_abs_url:
-                base = "/" + vpath + "/"
+                base = self.args.SRS
+                if vpath:
+                    base += vpath + "/"
                 href = base + fn
 
             if fn in vfs_virt:

--- a/copyparty/web/opds.xml
+++ b/copyparty/web/opds.xml
@@ -1,10 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <feed xmlns="http://www.w3.org/2005/Atom">
+    <id>{{ opds_id }}</id>
+    <title>{{ opds_title | e }}</title>
     <link rel="search"
     href="{{ opds_osd | e }}"
     type="application/opensearchdescription+xml"/>
     {%- for d in dirs %}
     <entry>
+        <id>{{ d.opds_id }}</id>
         <title>{{ d.name | e }}</title>
         <link rel="subsection"
         href="{{ d.href | e }}"
@@ -14,6 +17,7 @@
     {%- endfor %}
     {%- for f in files %}
     <entry>
+        <id>{{ f.opds_id }}</id>
         <title>{{ f.name | e }}</title>
         <updated>{{ f.iso8601 }}</updated>
         <link rel="http://opds-spec.org/acquisition"


### PR DESCRIPTION
Hi! I didn't read the whole OPDS 1.2 specification, but here are some things I've noticed:
- some readers require feeds and entries to have `id` and `title` fields
- some readers handle absolute URIs better than relative paths (even OPDS documentation uses absolute paths in all of examples)

So I've added missing `id` and `title` and changed relative urls to absolute.

---
This PR complies with the DCO; https://developercertificate.org/  
