### PR TITLE
support fd-based s6 notification protocol

### DIFF
--- a/copyparty/svchub.py
+++ b/copyparty/svchub.py
@@ -987,6 +987,10 @@ class SvcHub(object):
 
         Daemon(self.sd_notify, "sd-notify")
 
+        zb = os.environ.get("S6_NOTIFY_FD")
+        if zb:
+            Daemon(self.s6_notify, "s6-notify", (zb,))
+
     def _feature_test(self) -> None:
         fok = []
         fng = []
@@ -1896,6 +1900,17 @@ class SvcHub(object):
             sck.sendall(b"READY=1")
         except:
             self.log("sd_notify", min_ex())
+
+    def s6_notify(self, zb: bytes) -> None:
+        try:
+            fd = int(zb)
+            if fd < 3:
+                raise Exception("value < 3")
+            os.write(fd, b"\n")
+            os.close(fd)
+        except:
+            t = "S6_NOTIFY_FD=%s:\n%s"
+            self.log("s6-notify", t % (zb, min_ex()), 1)
 
     def log_stacks(self) -> None:
         td = time.time() - self.tstack


### PR DESCRIPTION
s6 notification protocol is a simple protocol to notify the supervisor when the daemon is ready to serve its purpose.

Just write a newline to the fd specified by the -fd argument and close it, and then the supervisor marks the daemon as started.

Dinit and s6 supervision suite are known to support this protocol.

Tested with three cases:
1. "copyparty-sfx.py -c config.conf" and everything works as expected.
2. "copyparty-sfx.py -c config.conf -fd 3" when using Dinit and its "ready-notification: pipefd:3" option.
3. "copyparty-sfx.py -c config.conf -fd 3" but without the 3 fd being open which logs a warning from s6-notification.

See https://skarnet.org/software/s6/notifywhenup.html and https://davmac.org/projects/dinit/man-pages-html/dinit-service.5.html#ready for details regarding its usage.

Signed-off-by: Mobin Aydinfar <mobin@mobintestserver.ir>
This PR complies with the DCO; https://developercertificate.org/  
