### PR TITLE
Add more dependencies to rc.d script.

### DIFF
--- a/contrib/rc/copyparty
+++ b/contrib/rc/copyparty
@@ -1,7 +1,7 @@
 #!/bin/sh
 #
 # PROVIDE: copyparty
-# REQUIRE: networking
+# REQUIRE: networking DAEMON FILESYSTEMS mountd
 # KEYWORD:
 
 . /etc/rc.subr


### PR DESCRIPTION
On my FreeBSD machine, copyparty wasn't starting with the computer even after being enabled. Turns out it was being started first, before all the filesystems and such showed up. This fixed it real nice.

This PR complies with the DCO; https://developercertificate.org/  
