### PR TITLE
invalidate get-only shares when creator no longer exists

### DIFF
--- a/copyparty/authsrv.py
+++ b/copyparty/authsrv.py
@@ -3113,7 +3113,7 @@ class AuthSrv(object):
 
                 try:
                     s_vfs, s_rem = vfs.get(
-                        s_vp, s_un, "r" in s_pr, "w" in s_pr, "m" in s_pr, "d" in s_pr
+                        s_vp, s_un, "r" in s_pr, "w" in s_pr, "m" in s_pr, "d" in s_pr, "g" in s_pr,
                     )
                 except Exception as ex:
                     t = "removing share [%s] by [%s] to [%s] due to %r"


### PR DESCRIPTION
Fixes #1480

I noticed while making this fix: shares invalidated in this way don't actually get removed from the db. is that intended?


This PR complies with the DCO; https://developercertificate.org/  
