### PR TITLE
auth: read (and admin) implies get

### DIFF
--- a/copyparty/authsrv.py
+++ b/copyparty/authsrv.py
@@ -1663,7 +1663,8 @@ class AuthSrv(object):
             for alias, mapping in [
                 ("h", "gh"),
                 ("G", "gG"),
-                ("A", "rwmda.A"),
+                ("r", "g"),
+                ("A", "rgwmda.A"),
             ]:
                 expanded = ""
                 for ch in mapping:

--- a/copyparty/httpcli.py
+++ b/copyparty/httpcli.py
@@ -6443,6 +6443,7 @@ class HttpCli(object):
         s_wr = "write" in req["perms"]
         s_get = "get" in req["perms"]
         s_dot = "dot" in req["perms"]
+        # will_read, will_write, will_move, will_del, will_get
         s_axs = [s_rd, s_wr, False, False, s_get]
         s_axsd = s_axs + [s_dot]
 

--- a/copyparty/web/browser.js
+++ b/copyparty/web/browser.js
@@ -4145,6 +4145,8 @@ var fileman = (function () {
 			if (this.textContent == 'write-only')
 				for (var a = 0; a < pbtns.length; a++)
 					clmod(pbtns[a], 'on', pbtns[a].textContent == 'write');
+			if (this.textContent == 'get' && clgot(this, 'on') && has(perms, 'read'))
+				clmod(pbtns[0], 'on');
 		}
 		clmod(pbtns[0], 'on', 1);
 
@@ -8032,22 +8034,18 @@ function apply_perms(res) {
 
 	a.style.display = '';
 	tt.att(QS('#ops'));
-	// read implies get, no need to show it
-	var displayed_perms = perms.slice(0);
-	var have_read = has(displayed_perms, 'read')
-	if (have_read) {
-		var get_index = displayed_perms.indexOf('get');
-		if (get_index > -1) {
-			displayed_perms.splice(get_index, 1);
-		}
-	}
+
+	var v_perms = perms.slice(0);
+	var have_read = has(perms, 'read');
+	if (have_read)
+		apop(v_perms, 'get');
 
 	for (var a = 0; a < chk.length; a++)
-		if (has(displayed_perms, chk[a]))
+		if (has(v_perms, chk[a]))
 			axs.push(chk[a].slice(0, 1).toUpperCase() + chk[a].slice(1));
 
 	axs = axs.join('-');
-	if (displayed_perms.length == 1) {
+	if (v_perms.length == 1) {
 		aclass = ' class="warn">';
 		axs += '-Only';
 	}

--- a/copyparty/web/browser.js
+++ b/copyparty/web/browser.js
@@ -8032,13 +8032,22 @@ function apply_perms(res) {
 
 	a.style.display = '';
 	tt.att(QS('#ops'));
+	// read implies get, no need to show it
+	var displayed_perms = perms.slice(0);
+	var have_read = has(displayed_perms, 'read')
+	if (have_read) {
+		var get_index = displayed_perms.indexOf('get');
+		if (get_index > -1) {
+			displayed_perms.splice(get_index, 1);
+		}
+	}
 
 	for (var a = 0; a < chk.length; a++)
-		if (has(perms, chk[a]))
+		if (has(displayed_perms, chk[a]))
 			axs.push(chk[a].slice(0, 1).toUpperCase() + chk[a].slice(1));
 
 	axs = axs.join('-');
-	if (perms.length == 1) {
+	if (displayed_perms.length == 1) {
 		aclass = ' class="warn">';
 		axs += '-Only';
 	}
@@ -8080,7 +8089,6 @@ function apply_perms(res) {
 	document.body.setAttribute('perms', perms.join(' '));
 
 	var have_write = has(perms, "write"),
-		have_read = has(perms, "read"),
 		de = document.documentElement,
 		tds = QSA('#u2conf td');
 


### PR DESCRIPTION
also, hide redundant get permission in webui

Closes #1483

hopefully this fix is at the correct layer; I didn't do a thorough search for things that may get affected by the permission alias, but making shares with get permission works when the creator has just read permission, and at least the webui won't get cluttered because of it

This PR complies with the DCO; https://developercertificate.org/  
