### PR TITLE
feat: Add option to render spectrograms with log frequency scale

### DIFF
--- a/copyparty/__main__.py
+++ b/copyparty/__main__.py
@@ -1769,6 +1769,7 @@ def add_thumbnail(ap):
     ap2.add_argument("--th-pre-rl", metavar="SEC", type=int, default=30, help="while pregen is running, ratelimit the thumbnailer logger to one message every \033[33mSEC\033[0m seconds (only works with \033[33m-j1\033[0m); set 0 to disable ratelimit")
     ap2.add_argument("--th-covers", metavar="N,N", type=u, default="folder.png,folder.jpg,cover.png,cover.jpg", help="folder thumbnails to stat/look for; enabling \033[33m-e2d\033[0m will make these case-insensitive, and try them as dotfiles (.folder.jpg), and also automatically select thumbnails for all folders that contain pics, even if none match this pattern")
     ap2.add_argument("--th-spec-p", metavar="N", type=u, default=1, help="for music, do spectrograms or embedded coverart? [\033[32m0\033[0m]=only-art, [\033[32m1\033[0m]=prefer-art, [\033[32m2\033[0m]=only-spec")
+    ap2.add_argument("--th-spec-fl", action="store_true", help="generate spectrograms with logarithmic frequency scale instead of linear")
     # https://pillow.readthedocs.io/en/stable/handbook/image-file-formats.html
     # https://github.com/libvips/libvips
     # https://stackoverflow.com/a/47612661

--- a/copyparty/th_srv.py
+++ b/copyparty/th_srv.py
@@ -1056,11 +1056,13 @@ class ThumbSrv(object):
             # fmt: on
             self._run_ff(cmd, vn, "convt")
 
+        fscale = ":fscale=log" if self.args.th_spec_fl else ""
+
         fc = "[0:a:0]aresample=48000{},showspectrumpic=s="
         if "3" in fmt:
-            fc += "1280x1024,crop=1420:1056:70:48[o]"
+            fc += "1280x1024%s,crop=1420:1056:70:48[o]" % fscale
         else:
-            fc += "640x512,crop=780:544:70:48[o]"
+            fc += "640x512%s,crop=780:544:70:48[o]" % fscale
 
         if self.args.th_ff_swr:
             fco = ":filter_size=128:cutoff=0.877"

--- a/copyparty/th_srv.py
+++ b/copyparty/th_srv.py
@@ -467,6 +467,11 @@ class ThumbSrv(object):
         zs = "th_dec th_no_webp th_no_jpg"
         for zs in zs.split(" "):
             ret.append("%s(%s)\n" % (zs, getattr(self.args, zs)))
+        zs = "th_spec_fl"
+        for zs in zs.split(" "):
+            v = getattr(self.args, zs)
+            if v:
+                ret.append("%s(%s)\n" % (zs, v))
         zs = "th_qv th_qvx thsize th_spec_p convt"
         for zs in zs.split(" "):
             ret.append("%s(%s)\n" % (zs, vn.flags.get(zs)))


### PR DESCRIPTION
This implements the feature described in #1486 .

It adds the argument ``th-spec-fl`` (thumbnails -> spectrogram -> frequency log scale) (please advise on a better name, this is what i decided on at 1am).
Adding this argument adds ``:fscale=log`` to the ffmpeg ``showspectrumpic`` filter, making it use a logarithmic scale instead of linear.

I tested this on my dev machine and it's now running in my prod deployment on my media server and seems to work well.

If spectrum pics were used previously, you have to clear the cache or non-linear pics will stick around.
Is there a fix for this, like invalidating all generated thumbnails if the arg was changed from the last run? 
Couldn't find anything like that in the code base yet.

Thank you for this awesome project, I hope this is good enough for a first contribution.

This PR complies with the DCO; https://developercertificate.org/  
