### PR TITLE
Add protocol wildcard in origin check (acao)

### DIFF
--- a/copyparty/httpcli.py
+++ b/copyparty/httpcli.py
@@ -1315,6 +1315,7 @@ class HttpCli(object):
         if (
             self.args.pw_hdr in ih
             or re.sub(r"(:[0-9]{1,5})?/?$", "", origin) in good_origins
+            or f"{origin.split('://')[0]}://*" in good_origins
         ):
             good_origin = True
             bad_hdrs = ("",)


### PR DESCRIPTION
Adds the ability to wildcard a specific protocol in --acao, mainly for allowing browser extensions (`--acao http://domain.tld,https://domain.tld,moz-extension://*`)

Basically, I'm using floccus to synchronize my bookmarks, but it's always sending `Origin: moz-extension://[its extension ID, which isn't fixed]`, which doesn't match the request's `https` protocol.

This PR allows wildcarding a specific protocol.


---

This PR complies with the DCO; https://developercertificate.org/  

---

PS: Love your work, everyone :D