### PR TITLE
separate dinit and s6 in s6-notify documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ you may also want these, especially on servers:
 because the following environment variables are commonly used in service-scripts, they are understood by copyparty:
 
 * `NOTIFY_SOCKET` as provided by systemd with service type=notify (see systemd/copyparty.service above)
-* `S6_NOTIFY_FD` for s6/dinit [`ready-notification = pipevar:S6_NOTIFY_FD`](https://skarnet.org/software/s6/notifywhenup.html)
+* `S6_NOTIFY_FD` for dinit [`ready-notification = pipevar:S6_NOTIFY_FD`](https://davmac.org/projects/dinit/man-pages-html/dinit-service.5.html#ready) and [s6 supervision suite notification](https://skarnet.org/software/s6/notifywhenup.html) support
 
 and remember to open the ports you want; here's a complete example including every feature copyparty has to offer:
 ```


### PR DESCRIPTION
The way to use the S6_NOTIFY_FD is different between dinit and s6 but the README only mentioned dinit syntax with a link to the s6 documentation.

`Signed-off-by: Mobin Aydinfar <mobin@mobintestserver.ir>`
This PR complies with the DCO; https://developercertificate.org/  
