### PR TITLE
added a flag to allow setting an ftp banner

### DIFF
--- a/copyparty/__main__.py
+++ b/copyparty/__main__.py
@@ -1519,7 +1519,7 @@ def add_ftp(ap):
     ap2.add_argument("--ftp-wt", metavar="SEC", type=int, default=7, help="grace period for resuming interrupted uploads (any client can write to any file last-modified more recently than \033[33mSEC\033[0m seconds ago)")
     ap2.add_argument("--ftp-nat", metavar="ADDR", type=u, default="", help="the NAT address to use for passive connections")
     ap2.add_argument("--ftp-pr", metavar="P-P", type=u, default="", help="the range of TCP ports to use for passive connections, for example \033[32m12000-13000")
-    ap2.add_argument("--ftp-banner", metavar="T", type=u, default="welcome to the party", help="bannertext to send when someone connects; can be @filepath (loaded into memory on startup); max 75 chars; no newlines")
+    ap2.add_argument("--ftp-banner", metavar="T", type=u, default="welcome to the party", help="bannertext to send when someone connects; \\n is newline, can be @filepath (loaded into memory on startup); if it has a newline then banner must be longer than 75 chars")
 
 
 def add_webdav(ap):

--- a/copyparty/__main__.py
+++ b/copyparty/__main__.py
@@ -1519,6 +1519,7 @@ def add_ftp(ap):
     ap2.add_argument("--ftp-wt", metavar="SEC", type=int, default=7, help="grace period for resuming interrupted uploads (any client can write to any file last-modified more recently than \033[33mSEC\033[0m seconds ago)")
     ap2.add_argument("--ftp-nat", metavar="ADDR", type=u, default="", help="the NAT address to use for passive connections")
     ap2.add_argument("--ftp-pr", metavar="P-P", type=u, default="", help="the range of TCP ports to use for passive connections, for example \033[32m12000-13000")
+    ap2.add_argument("--ftp-banner", metavar="BANNER", type=u, default="copyparty ftpd", help="banner to send before ftp login")
 
 
 def add_webdav(ap):

--- a/copyparty/__main__.py
+++ b/copyparty/__main__.py
@@ -1519,7 +1519,7 @@ def add_ftp(ap):
     ap2.add_argument("--ftp-wt", metavar="SEC", type=int, default=7, help="grace period for resuming interrupted uploads (any client can write to any file last-modified more recently than \033[33mSEC\033[0m seconds ago)")
     ap2.add_argument("--ftp-nat", metavar="ADDR", type=u, default="", help="the NAT address to use for passive connections")
     ap2.add_argument("--ftp-pr", metavar="P-P", type=u, default="", help="the range of TCP ports to use for passive connections, for example \033[32m12000-13000")
-    ap2.add_argument("--ftp-banner", metavar="BANNER", type=u, default="copyparty ftpd", help="banner to send before ftp login")
+    ap2.add_argument("--ftp-banner", metavar="T", type=u, default="welcome to the party", help="bannertext to send when someone connects; can be @filepath (loaded into memory on startup); max 75 chars; no newlines")
 
 
 def add_webdav(ap):

--- a/copyparty/ftpd.py
+++ b/copyparty/ftpd.py
@@ -629,7 +629,7 @@ class Ftpd(object):
             FtpHandler.hub = h2.hub = hub
             FtpHandler.args = h2.args = hub.args
             FtpHandler.authorizer = h2.authorizer = FtpAuth(hub)
-
+            FtpHandler.banner = self.args.ftp_banner
             if self.args.ftp_pr:
                 p1, p2 = [int(x) for x in self.args.ftp_pr.split("-")]
                 if self.args.ftp and self.args.ftps:

--- a/copyparty/ftpd.py
+++ b/copyparty/ftpd.py
@@ -625,10 +625,10 @@ class Ftpd(object):
 
             hs.append([h1, self.args.ftps])
 
-        zs = self.args.ftp_banner
+        zs = self.args.ftp_banner.replace("\\n", "\n")
         if zs.startswith("@"):
             zs = read_utf8(None, zs[1:], False)
-        banner = zs.replace("\r", "").replace("\n", "").strip()
+        banner = zs.replace("\r", "").replace("\n", "\r\n").strip()
 
         for h_lp in hs:
             h2, lp = h_lp

--- a/copyparty/ftpd.py
+++ b/copyparty/ftpd.py
@@ -28,6 +28,7 @@ from .util import (
     fsenc,
     ipnorm,
     pybin,
+    read_utf8,
     relchk,
     runhook,
     sanitize_fn,
@@ -624,12 +625,18 @@ class Ftpd(object):
 
             hs.append([h1, self.args.ftps])
 
+        zs = self.args.ftp_banner
+        if zs.startswith("@"):
+            zs = read_utf8(None, zs[1:], False)
+        banner = zs.replace("\r", "").replace("\n", "").strip()
+
         for h_lp in hs:
             h2, lp = h_lp
             FtpHandler.hub = h2.hub = hub
             FtpHandler.args = h2.args = hub.args
             FtpHandler.authorizer = h2.authorizer = FtpAuth(hub)
-            FtpHandler.banner = self.args.ftp_banner.replace("\\n", "\r\n")
+            FtpHandler.banner = banner
+
             if self.args.ftp_pr:
                 p1, p2 = [int(x) for x in self.args.ftp_pr.split("-")]
                 if self.args.ftp and self.args.ftps:

--- a/copyparty/ftpd.py
+++ b/copyparty/ftpd.py
@@ -629,7 +629,7 @@ class Ftpd(object):
             FtpHandler.hub = h2.hub = hub
             FtpHandler.args = h2.args = hub.args
             FtpHandler.authorizer = h2.authorizer = FtpAuth(hub)
-            FtpHandler.banner = self.args.ftp_banner
+            FtpHandler.banner = self.args.ftp_banner.replace("\\n", "\r\n")
             if self.args.ftp_pr:
                 p1, p2 = [int(x) for x in self.args.ftp_pr.split("-")]
                 if self.args.ftp and self.args.ftps:


### PR DESCRIPTION
this just adds a --ftp-banner flag that takes in some text to display as the banner on ftp USER command. makes it look like this, assuming `--ftp-banner "meow"`
this fixes some random dude's desire mentioned in #1503 
```
doskel@novensides ~/copyparty (hovudstraum)> ftp localhost 2121
Connected to localhost.
220 meow
Name (localhost:doskel): anonymous
331 Username ok, send password.
[...]
```
This PR complies with the DCO; https://developercertificate.org/  
