### PR TITLE
Add contrib example for traefik and docker

### DIFF
--- a/contrib/traefik/traefik-docker/copyparty.compose.yml
+++ b/contrib/traefik/traefik-docker/copyparty.compose.yml
@@ -1,0 +1,36 @@
+# docker-compose.yml for copyparty
+services:
+  copyparty:
+    image: copyparty/ac:latest
+    container_name: copyparty
+    user: "1000:1000"
+    volumes:
+      - ./:/cfg:z
+      - /path/to/your/fileshare/top/folder:/w:z
+  
+    environment:
+      LD_PRELOAD: /usr/lib/libmimalloc-secure.so.NOPE
+      # enable mimalloc by replacing "NOPE" with "2" for a nice speed-boost (will use twice as much ram)
+
+      PYTHONUNBUFFERED: 1
+      # ensures log-messages are not delayed (but can reduce speed a tiny bit)
+
+    stop_grace_period: 15s  # thumbnailer is allowed to continue finishing up for 10s after the shutdown signal
+    healthcheck:
+      # hide it from logs with "/._" so it matches the default --lf-url filter 
+      test: ["CMD-SHELL", "wget --spider -q 127.0.0.1:3923/?reset=/._"]
+      interval: 1m
+      timeout: 2s
+      retries: 5
+      start_period: 15s
+    networks:
+      - traefik_default
+    labels:
+      - traefik.http.routers.copyparty.rule=Host(`<DOMAIN>`)
+      - traefik.http.services.copyparty.loadbalancer.server.port=3923
+      - traefik.http.routers.copyparty.tls.certresolver=le
+      - traefik.http.routers.copyparty.entrypoints=websecure
+  
+networks:
+  traefik_default:
+    external: true

--- a/contrib/traefik/traefik-docker/copyparty.conf
+++ b/contrib/traefik/traefik-docker/copyparty.conf
@@ -1,0 +1,43 @@
+# note: copied from copyparty/docs/examples/docker/basic-docker-compose/copyparty.conf
+# not actually YAML but lets pretend:
+# -*- mode: yaml -*-
+# vim: ft=yaml:
+
+
+[global]
+  e2dsa  # enable file indexing and filesystem scanning
+  e2ts   # enable multimedia indexing
+  ansi   # enable colors in log messages (both in logfiles and stdout)
+
+  # q, lo: /cfg/log/%Y-%m%d.log   # log to file instead of docker
+
+  # p: 3939          # listen on another port
+  # ipa: 10.89.      # only allow connections from 10.89.*
+  # ipa: 172.16.4.0/23  # ...or only 172.16.4.* and 172.16.5.*
+  # ipa: lan         # ...or allow LAN only; reject internet IPs
+  # df: 16           # stop accepting uploads if less than 16 GB free disk space
+  # ver              # show copyparty version in the controlpanel
+  # grid             # show thumbnails/grid-view by default
+  # theme: 2         # monokai
+  # name: datasaver  # change the server-name that's displayed in the browser
+  # stats, nos-dup   # enable the prometheus endpoint, but disable the dupes counter (too slow)
+  # no-robots, force-js  # make it harder for search engines to read your server
+
+  # enable version-checking by uncommenting one of the vc-url lines below;
+  # shows a warning-banner in the controlpanel if your version has a known vulnerability
+  #vc-url: https://api.github.com/repos/9001/copyparty/security-advisories?per_page=9
+  #vc-url: https://api.copyparty.eu/advisories
+  vc-exit  # panic and shutdown instead of just showing the warning
+
+
+[accounts]
+  ed: wark  # username: password
+
+
+[/]            # create a volume at "/" (the webroot), which will
+  /w           # share /w (the docker data volume)
+  accs:
+    rw: *      # everyone gets read-write access, but
+    rwmda: ed  # the user "ed" gets read-write-move-delete-admin
+  flags:
+    e2ds       # enable filesystem-scanning for this volume only

--- a/contrib/traefik/traefik-docker/traefik.compose.yml
+++ b/contrib/traefik/traefik-docker/traefik.compose.yml
@@ -1,0 +1,34 @@
+# docker-compose.yml for traefik
+services:
+  traefik:
+    image: traefik:latest
+    command:
+      - --api.insecure=false
+      - --api.dashboard=true
+      - --providers.docker=true
+      - --entrypoints.web.address=:80
+      - --entrypoints.websecure.address=:443
+      - --entryPoints.websecure.http.tls=true
+      - --entryPoints.web.http.redirections.entryPoint.to=websecure
+      - --entryPoints.web.http.redirections.entryPoint.scheme=https
+      - --certificatesresolvers.le.acme.email=<your email here>
+      - --certificatesresolvers.le.acme.storage=/letsencrypt/acme.json
+      - --certificatesresolvers.le.acme.httpchallenge.entrypoint=web
+    ports:
+      - 80:80
+      - 443:443
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ./letsencrypt:/letsencrypt
+    labels:
+      # OPTIONAL: host your traefik dashboard on <DOMAIN>
+      # - traefik.http.routers.traefik-dash.rule=Host(`<DOMAIN>`)
+      # - traefik.http.routers.traefik-dash.entrypoints=websecure
+      # - traefik.http.routers.traefik-dash.service=api@internal
+      # - traefik.http.routers.traefik-dash.tls.certresolver=le
+      # - traefik.http.routers.traefik-dash.middlewares=traefik-dash-auth,traefik-dash-redirect
+      # - traefik.http.middlewares.traefik-dash-auth.basicauth.users=<USERNAME>:<HTPASSWD_ENCODED_PASSWD>
+      # - traefik.http.middlewares.traefik-dash-redirect.redirectregex.regex=^https://<SUBDOMAIN>\.<DOMAIN>\.TLD/?$
+      # - traefik.http.middlewares.traefik-dash-redirect.redirectregex.replacement=https://<DOMAIN>/dashboard/
+
+networks: {}


### PR DESCRIPTION
The included traefik example uses the traefik yml file, and I know a lot of people (me included) use Docker labels to configure traefik, so I thought this would be helpful.


This PR complies with the DCO; https://developercertificate.org/  
