### PR TITLE
fix(rotf): use global rotf-tz as volume fallback

### DIFF
--- a/copyparty/authsrv.py
+++ b/copyparty/authsrv.py
@@ -2328,7 +2328,7 @@ class AuthSrv(object):
             zs = vol.flags.get("rotf")
             if zs:
                 use = True
-                lim.set_rotf(zs, vol.flags.get("rotf_tz") or "UTC")
+                lim.set_rotf(zs, vol.flags.get("rotf_tz", self.args.rotf_tz) or "UTC")
 
             zs = vol.flags.get("maxn")
             if zs:


### PR DESCRIPTION
When a volume has `rotf` enabled but does not have `rotf-tz` as a volflag, fallback to global level `rotf-tz` instead of UTC.

Fixes #1525

---

This PR complies with the DCO; https://developercertificate.org/  
