### PR TITLE
fix: improve directory sorting

### DIFF
--- a/copyparty/httpcli.py
+++ b/copyparty/httpcli.py
@@ -7470,10 +7470,10 @@ class HttpCli(object):
             if doctxt is not None:
                 j2a["doc"] = doctxt
 
+        dirs.sort(key=itemgetter("name"))
+
         for d in dirs:
             d["name"] += "/"
-
-        dirs.sort(key=itemgetter("name"))
 
         if is_opds:
             # OpenSearch Description format requires a full-qualified URL and a "Short Name" under 16 characters

--- a/copyparty/web/browser.js
+++ b/copyparty/web/browser.js
@@ -3760,7 +3760,7 @@ function sortfiles(nodes) {
 					if ((v + '').indexOf('<a ') === 0)
 						v = v.split('>')[1];
 					else if (name == "href" && v)
-						v = uricom_dec(v);
+						v = uri2txt(v, true);
 
 					nodes[b]._sv = v
 				}
@@ -7873,7 +7873,7 @@ var treectl = (function () {
 		delete res['a'];
 		var keys = Object.keys(res);
 		for (var a = 0; a < keys.length; a++)
-			keys[a] = [uricom_dec(keys[a]), keys[a]];
+			keys[a] = [uri2txt(keys[a]), keys[a]];
 
 		if (ENATSORT)
 			keys.sort(function (a, b) { return NATSORT.compare(a[0], b[0]); });

--- a/copyparty/web/util.js
+++ b/copyparty/web/util.js
@@ -877,6 +877,16 @@ function url_enc(txt) {
     return ret.join('/');
 }
 
+function uri2txt(txt, unslash) {
+    try {
+      txt = decodeURIComponent(txt.split('?')[0]);
+    }
+    catch (ex) {
+        console.log("ucd-err [" + txt + "]");
+    }
+    return unslash ? txt.replace(/\/$/, '') : txt;
+}
+
 
 function uricom_dec(txt) {
     try {


### PR DESCRIPTION
Ignores the trailing slash, directory key or any other type of query before sorting.

Makes the directory sorting consistent with the filesystem and file sorting behavior in copyparty.

Fixes #1119 

---

This PR complies with the DCO; https://developercertificate.org/  
