### PR TITLE
nix: use ffmpeg-headless

### DIFF
--- a/README.md
+++ b/README.md
@@ -2636,8 +2636,6 @@ requires a [flake-enabled](https://nixos.wiki/wiki/Flakes) installation of nix
 
 some recommended dependencies are enabled by default; [override the package](https://github.com/9001/copyparty/blob/hovudstraum/contrib/package/nix/copyparty/default.nix#L3-L22) if you want to add/remove some features/deps
 
-`ffmpeg-full` was chosen over `ffmpeg-headless` mainly because we need `withWebp` (and `withOpenmpt` is also nice) and being able to use a cached build felt more important than optimizing for size at the time -- PRs welcome if you disagree 👍
-
 
 ## nixos module
 

--- a/contrib/package/nix/overlay.nix
+++ b/contrib/package/nix/overlay.nix
@@ -16,7 +16,7 @@ let
     withMagic = true;
   };
 
-  call = attrs: final.python3.pkgs.callPackage ./copyparty ({ ffmpeg = final.ffmpeg-full; } // attrs);
+  call = attrs: final.python3.pkgs.callPackage ./copyparty ({ ffmpeg = final.ffmpeg-headless; } // attrs);
 in
 {
   copyparty = call { stable = true; };


### PR DESCRIPTION
This PR complies with the DCO; https://developercertificate.org

---

I noticed the default build has a gigantic closure size of ~1.6GiB and wanted to reduce it, since the majority came from graphical libraries.

Swapping `ffmpeg-full` for `ffmpeg-headless` brings the closure size down to ~600MiB. Since late 2024 `ffmpeg-headless` has used `withWebp` and `withOpenmpt` (see https://github.com/NixOS/nixpkgs/commit/193b98084a08ed2b8b55880f77f0525ed915e16e and https://github.com/NixOS/nixpkgs/commit/2fa42d7b13c4b9c39aa19a5680b1ca81faed99a2 respectively) so the reasons in favor of `ffmpeg-full` in the README do not apply anymore.