### PR TITLE
Fix error in running forked hooks

### DIFF
--- a/copyparty/util.py
+++ b/copyparty/util.py
@@ -4033,7 +4033,7 @@ def runihook(
 
     t0 = time.time()
     if fork:
-        Daemon(runcmd, cmd, bcmd, ka=sp_ka)
+        Daemon(runcmd, cmd, [bcmd], ka=sp_ka)
     else:
         rc, v, err = runcmd(bcmd, **sp_ka)  # type: ignore
         if chk and rc:


### PR DESCRIPTION
This fixes an error in the `_runhook` function, where, if the fork flag was set, it would incorrectly pass the hook arguments into the Daemon function.
If more than one argument was passed into the hook, it would treat the second argument as the `timeout` argument of the `runcmd` function and since that argument also gets passed as a keyword argument, it effectively gets passed twice, crashing the thread.

This PR complies with the DCO; https://developercertificate.org/ :)
