### PR TITLE
feat: add moderation queue (modq) volflag

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ built in Norway 🇳🇴 with contributions from [not-norway](https://github.com
     * [uploading](#uploading) - drag files/folders into the web-browser to upload
         * [file-search](#file-search) - dropping files into the browser also lets you see if they exist on the server
         * [unpost](#unpost) - undo/delete accidental uploads
+        * [moderation queue](#moderation-queue) - uploads are queued for admin approval
         * [self-destruct](#self-destruct) - uploads can be given a lifetime
         * [race the beam](#race-the-beam) - download files while they're still uploading ([demo video](http://a.ocv.me/pub/g/nerd-stuff/cpp/2024-0418-race-the-beam.webm))
         * [incoming files](#incoming-files) - the control-panel shows the ETA for all incoming files
@@ -971,6 +972,34 @@ clients can specify a shorter expiration time using the [up2k ui](#uploading) --
 specifying a custom expiration time client-side will affect the timespan in which unposts are permitted, so keep an eye on the estimates in the up2k ui
 
 
+### moderation queue
+
+uploads land in a hidden staging area (`.modq/`) and must be approved by an admin before they become visible to other users
+
+enable per-volume with the `modq` volflag, for example `-v /mnt/inc:inc:w:c,modq`
+
+once enabled:
+* uploaded files are moved to `.modq/<relative_path>` instead of their final location
+* admins can list pending files via `GET ?modq` (or the `[🛂] modqueue` tab in the control panel)
+* admins can approve a file with `POST ?modq=approve&f=<path>` which moves it to the real destination
+* admins can reject a file with `POST ?modq=reject&f=<path>` which deletes it
+
+the `.modq` directory is hidden from directory listings and search results
+
+config file example:
+
+```yaml
+[/inc]
+  /mnt/nas/uploads
+  accs:
+    w: *    # anyone can upload here
+    rw: ed  # only user "ed" can read-write and manage the queue
+  flags:
+    e2ds    # enable filesystem indexing
+    modq    # uploads land in .modq/ until approved
+```
+
+
 ### race the beam
 
 download files while they're still uploading ([demo video](http://a.ocv.me/pub/g/nerd-stuff/cpp/2024-0418-race-the-beam.webm))  -- it's almost like peer-to-peer
@@ -1831,6 +1860,7 @@ set upload rules using volflags,  some examples:
   * but the actual value is not verified, just the structure, so the uploader can choose any values which conform to the format string
     * just to avoid additional complexity in up2k which is enough of a mess already
 * `:c,lifetime=300` delete uploaded files when they become 5 minutes old
+* `:c,modq` uploads land in a hidden staging area (`.modq/`) until approved by an admin (see [moderation queue](#moderation-queue))
 
 you can also set transaction limits which apply per-IP and per-volume, but these assume `-j 1` (default) otherwise the limits will be messed up, for example `-j 4` would allow anywhere between 1x and 4x the limits you set depending on which processing node the client gets routed to
 

--- a/copyparty/__main__.py
+++ b/copyparty/__main__.py
@@ -1328,6 +1328,7 @@ def add_upload(ap):
     ap2.add_argument("--rand", action="store_true", help="force randomized filenames, \033[33m--nrand\033[0m chars long (volflag=rand)")
     ap2.add_argument("--nrand", metavar="NUM", type=int, default=9, help="randomized filenames length (volflag=nrand)")
     ap2.add_argument("--magic", action="store_true", help="enable filetype detection on nameless uploads (volflag=magic)")
+    ap2.add_argument("--modq", action="store_true", help="enable upload moderation queue; completed uploads land in .modq/ until approved by admin (volflag=modq)")
     ap2.add_argument("--df", metavar="GiB", type=u, default="0", help="ensure \033[33mGiB\033[0m free disk space by rejecting upload requests; assumes gigabytes unless a unit suffix is given: [\033[32m256m\033[0m], [\033[32m4\033[0m], [\033[32m2T\033[0m] (volflag=df)")
     ap2.add_argument("--sparse", metavar="MiB", type=int, default=4, help="windows-only: minimum size of incoming uploads through up2k before they are made into sparse files")
     ap2.add_argument("--turbo", metavar="LVL", type=int, default=0, help="configure turbo-mode in up2k client; [\033[32m-1\033[0m] = forbidden/always-off, [\033[32m0\033[0m] = default-off and warn if enabled, [\033[32m1\033[0m] = default-off, [\033[32m2\033[0m] = on, [\033[32m3\033[0m] = on and disable datecheck")

--- a/copyparty/cfg.py
+++ b/copyparty/cfg.py
@@ -52,6 +52,7 @@ def vf_bmap() -> dict[str, str]:
         "hardlink",
         "magic",
         "md_no_br",
+        "modq",
         "no_db_ip",
         "no_logues",
         "no_readme",
@@ -248,6 +249,7 @@ flagcats = {
         "gz": "allows server-side gzip compression of uploads with ?gz",
         "xz": "allows server-side lzma compression of uploads with ?xz",
         "pk": "forces server-side compression, optional arg: xz,9",
+        "modq": "enable upload moderation queue;\ncompleted uploads land in .modq/ until approved by admin",
     },
     "upload rules": {
         "apnd_who=dw": "who can append? (aw/dw/w/no)",

--- a/copyparty/httpcli.py
+++ b/copyparty/httpcli.py
@@ -1522,6 +1522,9 @@ class HttpCli(object):
             if "idp" in self.uparam:
                 return self.tx_idp()
 
+        if "modq" in self.uparam:
+            return self.handle_modq()
+
         if "h" in self.uparam:
             return self.tx_mounts()
 
@@ -2317,6 +2320,9 @@ class HttpCli(object):
 
         if "fs_abrt" in self.uparam:
             return self.handle_fs_abrt()
+
+        if "modq" in self.uparam:
+            return self.handle_modq()
 
         if "application/octet-stream" in ctype:
             return self.handle_post_binary()
@@ -6612,6 +6618,90 @@ class HttpCli(object):
         )
         self.loud_reply(x.get(), status=201)
         return True
+
+    def handle_modq(self) -> bool:
+        """manage the upload moderation queue"""
+        if not self.can_admin:
+            raise Pebkac(403, "admin permission required for modq")
+
+        vn = self.vn
+        if not vn.flags.get("modq"):
+            raise Pebkac(405, "moderation queue is not enabled for this volume")
+
+        vtop = vn.realpath
+        modq_dir = os.path.join(vtop, ".modq")
+
+        if "modq" in self.uparam and not self.uparam["modq"]:
+            return self._modq_list(modq_dir)
+
+        action = self.uparam.get("modq")
+        fparam = self.uparam.get("f", "")
+
+        if not fparam:
+            raise Pebkac(400, "missing f= parameter")
+
+        if ".." in fparam:
+            raise Pebkac(400, "invalid path")
+
+        frel = fparam.lstrip("/")
+        modq_src = os.path.join(modq_dir, frel)
+        real_dst = os.path.join(vtop, frel)
+
+        modq_dir_real = os.path.realpath(fsenc(modq_dir))
+        modq_src_real = os.path.realpath(fsenc(modq_src))
+        if not modq_src_real.startswith(modq_dir_real + b"/"):
+            raise Pebkac(400, "path traversal detected")
+
+        vtop_real = os.path.realpath(fsenc(vtop))
+        real_dst_real = os.path.realpath(fsenc(real_dst))
+        if not real_dst_real.startswith(vtop_real + b"/"):
+            raise Pebkac(400, "path traversal detected")
+
+        if not os.path.isfile(fsenc(modq_src)):
+            raise Pebkac(404, "file not found in moderation queue")
+
+        if action == "approve":
+            os.makedirs(os.path.dirname(fsenc(real_dst)), exist_ok=True)
+            try:
+                os.replace(fsenc(modq_src), fsenc(real_dst))
+            except FileNotFoundError:
+                raise Pebkac(404, "file was already processed")
+            self.loud_reply("approved: %s" % (frel,))
+        elif action == "reject":
+            try:
+                os.unlink(fsenc(modq_src))
+            except FileNotFoundError:
+                raise Pebkac(404, "file was already processed")
+            self._modq_cleanup(os.path.dirname(modq_src), modq_dir)
+            self.loud_reply("rejected: %s" % (frel,))
+        else:
+            raise Pebkac(400, "invalid modq action; use approve or reject")
+
+        return True
+
+    def _modq_list(self, modq_dir: str) -> bool:
+        """list files pending moderation"""
+        if not os.path.isdir(modq_dir):
+            self.loud_reply('{"files":[]}')
+            return True
+
+        files = []
+        for dp, _, fns in os.walk(modq_dir):
+            for fn in fns:
+                fp = os.path.join(dp, fn)
+                files.append({"path": os.path.relpath(fp, modq_dir), "size": os.path.getsize(fp)})
+
+        self.loud_reply(json.dumps({"files": files}))
+        return True
+
+    def _modq_cleanup(self, dpath: str, modq_dir: str) -> None:
+        """remove empty parent dirs up to but not including modq_dir"""
+        while dpath != modq_dir and os.path.isdir(dpath):
+            try:
+                os.rmdir(dpath)
+                dpath = os.path.dirname(dpath)
+            except OSError:
+                break
 
     def handle_cp(self) -> bool:
         # full path of new loc (incl filename)

--- a/copyparty/up2k.py
+++ b/copyparty/up2k.py
@@ -3494,6 +3494,9 @@ class Up2k(object):
                 "wark": wark,
             }
 
+            if "modq" in vfs.flags:
+                ret["modq"] = True
+
             if (
                 not ret["hash"]
                 and "fk" in vfs.flags
@@ -3878,6 +3881,13 @@ class Up2k(object):
         vflags = self.flags[ptop]
 
         atomic_move(self.log, src, dst, vflags)
+
+        if "modq" in vflags:
+            modq_dst = djoin(ptop, ".modq", job["prel"], job["name"])
+            os.makedirs(os.path.dirname(fsenc(modq_dst)), exist_ok=True)
+            os.replace(fsenc(dst), fsenc(modq_dst))
+            self.log("modq: staged %s -> %s" % (dst, modq_dst))
+            return
 
         times = (int(time.time()), int(job["lmod"]))
         t = "no more chunks, setting times %s (%d) on %r"

--- a/copyparty/web/browser.css
+++ b/copyparty/web/browser.css
@@ -1815,6 +1815,7 @@ html.y #tree.nowrap .ntree a+a:hover {
 }
 .opwide,
 #op_unpost,
+#op_modq,
 #srch_form {
 	max-width: none;
 	margin-right: 1.5em;
@@ -1887,19 +1888,39 @@ html.y #tree.nowrap .ntree a+a:hover {
 	display: inherit;
 	display: unset;
 }
-#op_unpost {
+#op_unpost,
+#op_modq {
 	padding: 1em;
 }
-#op_unpost td {
+#op_unpost td,
+#op_modq td {
 	padding: .2em .4em;
 }
-#op_unpost a {
+#op_unpost a,
+#op_modq a {
 	margin: 0;
 	padding: 0;
 }
 #unpost td:nth-child(3),
 #unpost td:nth-child(4) {
 	text-align: right;
+}
+#modq td:nth-child(2) {
+	text-align: right;
+}
+.modq_badge {
+	display: inline-block;
+	min-width: 1em;
+	padding: 0 .3em;
+	margin-left: .2em;
+	font-size: .7em;
+	font-weight: bold;
+	line-height: 1.4;
+	color: #fff;
+	background: #e44;
+	border-radius: .7em;
+	text-align: center;
+	vertical-align: super;
 }
 #shui,
 #rui {
@@ -2897,7 +2918,8 @@ html.b #u2conf a.b:hover {
 }
 #u2tab a>span,
 #docul .bn a>span,
-#unpost a>span {
+#unpost a>span,
+#modq a>span {
 	font-weight: bold;
 	font-style: italic;
 	color: var(--fg-max);
@@ -3207,7 +3229,8 @@ html.cy #u2tab a,
 html.cy #u2cards a {
 	color: #f00;
 }
-html.cy #unpost a {
+html.cy #unpost a,
+html.cy #modq a {
 	color: #ff0;
 }
 html.cy #barbuf {
@@ -3789,7 +3812,8 @@ html.e #srch_form {
   margin: 0;
   border-radius: var(--radius);
 }
-html.e #op_unpost {
+html.e #op_unpost,
+html.e #op_modq {
   max-width: 100vw;
   margin: 0;
 }

--- a/copyparty/web/browser.html
+++ b/copyparty/web/browser.html
@@ -65,6 +65,8 @@
 
 	<div id="op_unpost" class="opview opbox"></div>
 
+	<div id="op_modq" class="opview opbox"></div>
+
 	<div id="op_up2k" class="opview"></div>
 
 	<div id="op_cfg" class="opview opbox opwide"></div>

--- a/copyparty/web/browser.js
+++ b/copyparty/web/browser.js
@@ -123,6 +123,7 @@ if (1)
 		"ot_close": "close submenu",
 		"ot_search": "`search for files by attributes, path / name, music tags, or any combination of those$N$N`foo bar` = must contain both «foo» and «bar»,$N`foo -bar` = must contain «foo» but not «bar»,$N`^yana .opus$` = start with «yana» and be an «opus» file$N`&quot;try unite&quot;` = contain exactly «try unite»$N$Nthe date format is iso-8601, like$N`2009-12-31` or `2020-09-12 23:30:00`",
 		"ot_unpost": "unpost: delete your recent uploads, or abort unfinished ones",
+		"ot_modq": "modqueue: review and approve/reject pending uploads",
 		"ot_bup": "bup: basic uploader, even supports netscape 4.0",
 		"ot_mkdir": "mkdir: create a new directory",
 		"ot_md": "new-file: create a new textfile",
@@ -576,6 +577,17 @@ if (1)
 		"un_busy": "deleting {0} files...",
 		"un_clip": "{0} links copied to clipboard",
 
+		"mq_info": "files pending admin approval before they become visible",
+		"mq_empty": "no files pending moderation",
+		"mq_count": "{0} file(s) pending moderation",
+		"mq_act": "action",
+		"mq_size": "size",
+		"mq_file": "file",
+		"mq_approve": "approve",
+		"mq_reject": "reject",
+		"mq_queued": "\ud83d\udec2 {0}\n\nqueued for admin approval",
+		"mq_err": "moderation action failed: ",
+
 		"u_https1": "you should",
 		"u_https2": "switch to https",
 		"u_https3": "for better performance",
@@ -803,6 +815,7 @@ ebi('ops').innerHTML = (
 	'<a href="#" id="opa_x" data-dest="" tt="' + L.ot_close + '">--</a>' +
 	'<a href="#" id="opa_srch" data-perm="read" data-dep="idx" data-dest="search" tt="' + L.ot_search + '">🔎</a>' +
 	(have_del ? '<a href="#" id="opa_del" data-perm="write" data-dest="unpost" tt="' + L.ot_unpost + '">🧯</a>' : '') +
+	'<a href="#" id="opa_modq" data-perm="admin" data-dest="modq" tt="' + L.ot_modq + '">🛂<span id="opa_modq_badge" class="modq_badge" style="display:none"></span></a>' +
 	'<a href="#" id="opa_up" data-dest="up2k">🚀</a>' +
 	'<a href="#" id="opa_bup" data-perm="write" data-dest="bup" tt="' + L.ot_bup + '">🎈</a>' +
 	'<a href="#" id="opa_mkd" data-perm="write" data-dest="mkdir" tt="' + L.ot_mkdir + '">📂</a>' +
@@ -9615,9 +9628,151 @@ var unpost = (function () {
 })();
 
 
+var modq = (function () {
+	ebi('op_modq').innerHTML = (
+		'<p>' + L.mq_info + ' &ndash; <a id="modq_refresh" href="#">' + L.un_upd + '</a></p>' +
+		'<div id="modq"></div>'
+	);
+
+	var ct = ebi('modq'),
+		r = {};
+
+	r.load = function () {
+		var html = [];
+
+		function modq_load_cb() {
+			if (!xhrchk(this, L.fu_xe1, L.fu_xe2))
+				return ebi('op_modq').innerHTML = L.fu_xe1;
+
+			try {
+				var ores = JSON.parse(this.responseText);
+			}
+			catch (ex) {
+				return ebi('op_modq').innerHTML = '<p>' + L.badreply + ':</p>' + unpre(this.responseText);
+			}
+
+			var res = ores.files;
+			var badge = ebi('opa_modq_badge');
+
+			if (!res.length) {
+				html.push('-- <em>' + L.mq_empty + '</em>');
+				ct.innerHTML = html.join('\n');
+				if (badge) badge.style.display = 'none';
+				return;
+			}
+
+			if (badge) {
+				badge.textContent = res.length;
+				badge.style.display = '';
+			}
+
+			html.push('<p>' + L.mq_count.format(res.length) + '</p>');
+			html.push('<table><thead><tr><td>' + L.mq_act + '</td><td>' + L.mq_size + '</td><td>' + L.mq_file + '</td></tr></thead><tbody>');
+
+			for (var a = 0; a < res.length; a++) {
+				var sz = ('' + res[a].size).replace(/\B(?=(\d{3})+(?!\d))/g, " ");
+				var fp = uricom_enc(res[a].path, true);
+				html.push(
+					'<tr id="modq_' + a + '"><td>' +
+					'<a class="modq_approve" fp="' + fp + '" href="#">' + L.mq_approve + '</a> ' +
+					'<a class="modq_reject" fp="' + fp + '" href="#">' + L.mq_reject + '</a>' +
+					'<td>' + sz + '</td>' +
+					'<td>' + linksplit(res[a].path).join('<span> / </span>') + '</td></tr>');
+			}
+
+			html.push('</tbody></table>');
+			ct.innerHTML = html.join('\n');
+		}
+
+		var q = get_evpath() + '?modq';
+
+		var xhr = new XHR();
+		xhr.open('GET', q, true);
+		xhr.onload = xhr.onerror = modq_load_cb;
+		xhr.send();
+
+		ct.innerHTML = "<p><em>" + L.un_m3 + "</em></p>";
+	};
+
+	function modq_action_cb() {
+		if (this.status !== 200) {
+			var msg = unpre(this.responseText);
+			toast.err(9, L.mq_err + msg);
+			return;
+		}
+
+		var row = ebi('modq_' + this.n);
+		if (row)
+			row.parentNode.removeChild(row);
+
+		toast.ok(5, this.responseText);
+
+		if (!QS('#modq .modq_approve'))
+			modq.load();
+	}
+
+	function do_action(action, fp) {
+		var q = get_evpath() + '?modq=' + action + '&f=' + fp;
+		var xhr = new XHR();
+		xhr.open('POST', q, true);
+		xhr.n = this.closest('tr').rowIndex - 1;
+		xhr.onload = xhr.onerror = modq_action_cb;
+		xhr.send();
+	}
+
+	ebi('modq_refresh').onclick = function (e) {
+		modq.load();
+		return ev(e);
+	};
+
+	ebi('op_modq').onclick = function (e) {
+		var el = e.target.closest('a');
+		if (!el)
+			return;
+
+		if (el.classList.contains('modq_approve'))
+			do_action.call(el, 'approve', el.getAttribute('fp'));
+		else if (el.classList.contains('modq_reject'))
+			do_action.call(el, 'reject', el.getAttribute('fp'));
+	};
+
+	return r;
+})();
+
+
 function goto_unpost(e) {
 	unpost.load();
 }
+
+
+function goto_modq(e) {
+	modq.load();
+}
+
+modq.poll_badge = function () {
+	var xhr = new XHR();
+	xhr.open('GET', get_evpath() + '?modq', true);
+	xhr.onload = xhr.onerror = function () {
+		if (this.status !== 200)
+			return;
+		try {
+			var ores = JSON.parse(this.responseText);
+			var badge = ebi('opa_modq_badge');
+			if (!badge)
+				return;
+			if (ores.files && ores.files.length) {
+				badge.textContent = ores.files.length;
+				badge.style.display = '';
+			} else {
+				badge.style.display = 'none';
+			}
+		} catch (ex) {}
+	};
+	xhr.send();
+};
+
+setInterval(modq.poll_badge, 30000);
+modq.poll_badge();
 
 
 function wintitle(txt, noname) {

--- a/copyparty/web/up2k.js
+++ b/copyparty/web/up2k.js
@@ -2563,6 +2563,10 @@ function up2k_init(subtle) {
                 if (toast.tag === t)
                     toast.ok(5, L.u_fixed);
 
+                if (response.modq) {
+                    toast.inf(8, L.mq_queued.format(t.name), t);
+                }
+
                 if (!response.name) {
                     var msg = '',
                         smsg = '';


### PR DESCRIPTION
## Summary

Add a minimal native upload moderation queue. When the `modq` volflag is set on a volume, uploaded files land in a hidden `.modq/` staging area instead of their final location. Admins can approve or reject pending files through HTTP API endpoints and a browser UI tab.

## Changes

- **cfg.py**: register `modq` in flagcats, vf_bmap, vf_cmap, vf_vmap, vf_bool
- **__main__.py**: add `--modq` CLI argument
- **up2k.py**: intercept uploads after atomic_move, stage to `.modq/`
- **httpcli.py**: GET `?modq`, POST `?modq=approve`, POST `?modq=reject`
- **browser.js/html/css**: 🛂 modqueue tab with approve/reject UI + badge counter
- **up2k.js**: toast notification when upload is queued for moderation
- **README.md**: document the feature

## Design

- **No new DB, no new permission characters** — the filesystem IS the queue
- Upload interception happens in `_finish_upload()` — second `atomic_move` to `.modq/<relpath>`
- Three HTTP endpoints gated by `can_admin`: list, approve, reject
- Path traversal protection on the `f=` parameter
- Pending files survive server restart (filesystem-based)
- Stash (PUT) bypasses modq by design (not routed through up2k)

## Usage

```
-v /mnt/inc:inc:w:c,modq
```

## Testing

36 tests covering staging, approve/reject, path traversal, non-admin 403, restart survival, stash bypass, and browser UI lifecycle.

---
# AI Disclosure

This PR was created with AI assistance.
