### PR TITLE
map different copyparty hosts to different WOPI client addresses

### DIFF
--- a/copyparty/__main__.py
+++ b/copyparty/__main__.py
@@ -1587,6 +1587,7 @@ def add_wopi(ap):
     ap2.add_argument("--wopi", action="store_true", help="enable integration with office suites using WOPI")
     ap2.add_argument("--wopi-api", metavar="URL", type=u, default="", help="URL that the WOPI-client should use to communicate with copyparty; default is same as user's webbrowser. Example: [\033[32mhttps://party.example.com/\033[0m]")
     ap2.add_argument("--wopi-url", metavar="URL", type=u, default="", help="URL to your WOPI client; the host of e.g. Collabora Online. Example: [\033[32mhttps://code.example.com/\033[0m]")
+    ap2.add_argument("--wopi-urls", metavar="HOST=URL", type=u, action="append", help="\033[34mREPEATABLE:\033[0m maps http \033[33mHOST\033[0m copyparty being accessed by to specific WOPI client instance \033[33mURL\033[0m; falls back to \033[33m--wopi-url\033[0m; examples: [\033[32mparty.public.com=https://office.public.com/\033[0m], [\033[32mparty.internal.net:8443=https://office.internal.net:8443/\033[0m]")
     ap2.add_argument("--wopi-crt", metavar="TXT", type=u, default="", help="if \033[33m--wopi-url\033[0m is selfsigned: path to ca.pem or cert.pem to expect/verify (can be [\033[32mno\033[0m] for full-yolo)")
     ap2.add_argument("--wopi-crt-icn", action="store_true", help="if \033[33m--wopi-url\033[0m is selfsigned: ignore the CN (server ip/name) in cert")
     ap2.add_argument("--wopi-ttl", metavar="SEC", type=int, default=1800, help="session lifetime; allow editing for this many seconds (default is 30 min)")

--- a/copyparty/httpcli.py
+++ b/copyparty/httpcli.py
@@ -1672,8 +1672,8 @@ class HttpCli(object):
                     ctx.check_hostname = not self.args.wopi_crt_icn
 
                 uo_kw["context"] = ctx
-
-            url = self.args.wopi_url.rstrip("/") + "/hosting/discovery"
+            wopi_urls = dict(pair.split('=', 1) for pair in self.args.wopi_urls) if self.args.wopi_urls else dict()
+            url = wopi_urls.get(self.host, self.args.wopi_url).rstrip("/") + "/hosting/discovery"
             buf = urlopen(url, **uo_kw).read()
             xml = buf.decode("ascii", "replace").lower()
             enc = self.get_xml_enc(xml)

--- a/copyparty/httpcli.py
+++ b/copyparty/httpcli.py
@@ -1672,8 +1672,10 @@ class HttpCli(object):
                     ctx.check_hostname = not self.args.wopi_crt_icn
 
                 uo_kw["context"] = ctx
-            wopi_urls = dict(pair.split('=', 1) for pair in self.args.wopi_urls) if self.args.wopi_urls else dict()
-            url = wopi_urls.get(self.host, self.args.wopi_url).rstrip("/") + "/hosting/discovery"
+
+            wopi_urls = dict(x.lower().split("=", 1) for x in self.args.wopi_urls or [])
+            url = wopi_urls.get(self.host.lower(), self.args.wopi_url).rstrip("/")
+            url += "/hosting/discovery"
             buf = urlopen(url, **uo_kw).read()
             xml = buf.decode("ascii", "replace").lower()
             enc = self.get_xml_enc(xml)


### PR DESCRIPTION
original title: `allow serving wopi client on same host under diffetent path`

---

This PR complies with the DCO; https://developercertificate.org/  

---

closes #1579 