### PR TITLE
unbreak version checker in nixos module

### DIFF
--- a/contrib/nixos/modules/copyparty.nix
+++ b/contrib/nixos/modules/copyparty.nix
@@ -285,6 +285,7 @@ in
 
         environment = {
           PYTHONUNBUFFERED = "true";
+          NIX_SSL_CERT_FILE = "${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt";
           XDG_CONFIG_HOME = externalStateDir;
         };
 


### PR DESCRIPTION
Before the change, copyparty could not fetch advisories when run under provided NixOS module:

    02:37:29.189 ver-chk                BTW: will download advisory because cache-file '/var/lib/copyparty/copyparty/vuln_advisory.json' could not be read: [Errno 2] No such file or directory: '/var/lib/copyparty/copyparty/vuln_advisory.json'
    02:37:39.849 ver-chk               CRIT: failed to fetch vulnerability advisory; <urlopen error [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:1082)>

Nixpkgs patches many libraries to read certificate bundle mentioned in NIX_SSL_CERT_FILE environment variable, and /nix/store is already present in the sandbox.

I have considered poking a hole to /etc/ssl/certs and /etc/static/ssl/certs, but that felt hacky (as without etc overlay /etc/ssl has symlinks to /etc/static) and I don't feel like poking a filesystem hole (even a small one) for no real reason when I can just Not Do that.

Related to https://github.com/NixOS/nixpkgs/issues/409848

To show that your contribution is compatible with the MIT License, please include the following text somewhere in this PR description:  
This PR complies with the DCO; https://developercertificate.org/  
