### PR TITLE
wopi: fix onlyoffice opening docs in readonly mode

### DIFF
--- a/copyparty/httpcli.py
+++ b/copyparty/httpcli.py
@@ -1680,7 +1680,7 @@ class HttpCli(object):
             xml = buf.decode(enc, "replace")
             xroot = parse_xml(xml)
             ext = vpath.split(".")[-1]
-            url = xroot.find(".//action[@ext='%s'][@urlsrc]" % (ext,)).get("urlsrc")
+            url = xroot.find(".//action[@ext='%s'][@name='edit'][@urlsrc]" % (ext,)).get("urlsrc")
             if not url.endswith(("?", "&")):
                 url += "&" if "?" in url else "?"
             url += "WOPISrc="

--- a/copyparty/httpcli.py
+++ b/copyparty/httpcli.py
@@ -1680,7 +1680,9 @@ class HttpCli(object):
             xml = buf.decode(enc, "replace")
             xroot = parse_xml(xml)
             ext = vpath.split(".")[-1]
-            url = xroot.find(".//action[@ext='%s'][@name='edit'][@urlsrc]" % (ext,)).get("urlsrc")
+            url = xroot.find(
+                ".//action[@ext='%s'][@name='edit'][@urlsrc]" % (ext,)
+            ).get("urlsrc")
             if not url.endswith(("?", "&")):
                 url += "&" if "?" in url else "?"
             url += "WOPISrc="


### PR DESCRIPTION
This PR complies with the DCO; https://developercertificate.org/  

---

#1574 

I expect it to be safe for collabora and onlyoffice. Tried creating(through copyparty UI)/opening/editing/saving .docx and .xlsx files with both. It worked. 