### PR TITLE
wopi: fix access_token_ttl format

### DIFF
--- a/copyparty/httpcli.py
+++ b/copyparty/httpcli.py
@@ -1703,7 +1703,7 @@ class HttpCli(object):
             title=self.uparam["wopi"],
             url=url,
             atoken=atoken,
-            ttl=session["expires"],
+            ttl=int(session["expires"] * 1000),
         ).encode("utf-8", "replace")
 
         self.reply(html, 200, "text/html; charset=utf-8")

--- a/copyparty/web/wopi.html
+++ b/copyparty/web/wopi.html
@@ -27,7 +27,7 @@ body {
     <div style="display: none">
         <form action="{{ url }}" enctype="multipart/form-data" method="post" target="w" id="submit-form">
             <input name="access_token" value="{{ atoken }}" type="hidden" id="access-token"/>
-            <input name="access_token_ttl" value="{{ ttl }}000" type="hidden" id="access-token_ttl"/>
+            <input name="access_token_ttl" value="{{ ttl }}" type="hidden" id="access-token_ttl"/>
             <input type="submit" value="" />
         </form>
     </div>


### PR DESCRIPTION
This PR complies with the DCO; https://developercertificate.org/  

---

#1574

tested manually by setting `--wopi-ttl` to 120 seconds and spamming `save` in collabora until it refused to save in 120 seconds

no more misleading 'session expired' modals