### PR TITLE
fix: added backend generation of favicons

### DIFF
--- a/copyparty/httpcli.py
+++ b/copyparty/httpcli.py
@@ -1420,6 +1420,9 @@ class HttpCli(object):
             if "%" in self.req:
                 self.log(" `-- %r" % (self.vpath,))
 
+        if self.vpath == "favicon.ico":
+            return self.tx_favico()
+
         # "embedded" resources
         if self.vpath.startswith(".cpr"):
             if self.vpath.startswith(".cpr/ico/"):
@@ -5535,6 +5538,24 @@ class HttpCli(object):
             ext = "~" + ext[-9:]
 
         return self.tx_svg(ext, exact)
+
+    def tx_favico(self) -> bool:
+        dv = (self.args.favico or "🎉").split()
+        txt = html_escape(dv[0], True)
+        fg = dv[1] if len(dv) > 1 and dv[1].lower() != "none" else "fc5"
+        bg = dv[2] if len(dv) > 2 and dv[2].lower() != "none" else ""
+        bg_rect = '<rect width="100%%" height="100%%" rx="16" fill="#%s" />\n' % (bg,) if bg else ""
+        svg = (
+            '<?xml version="1.0" encoding="UTF-8"?>'
+            '<svg version="1.1" viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg">'
+            "%s"
+            '<text x="50%%" y="55%%" dominant-baseline="middle" text-anchor="middle"'
+            ' font-family="sans-serif" font-weight="bold" font-size="64px"'
+            ' fill="#%s">%s</text></svg>'
+        ) % (bg_rect, fg, txt)
+        self.permit_caching()
+        self.reply(svg.encode("utf-8"), mime="image/svg+xml")
+        return True
 
     def tx_svg(self, txt: str, small: bool = False) -> bool:
         # chrome cannot handle more than ~2000 unique SVGs


### PR DESCRIPTION
When bookmarking a site in Firefox it tries to use its `/favicon.ico` instead of the one set via frontend, this change replicates favicon generation from frontend to backend:
<img width="124" height="48" alt="image" src="https://github.com/user-attachments/assets/1fa0cf9f-6e8a-4916-84cb-348d93a482d5" />
<img width="110" height="41" alt="image" src="https://github.com/user-attachments/assets/7ce9aab7-cc45-415f-b1d9-df19a815afea" />




This PR complies with the DCO; https://developercertificate.org/  
