### PR TITLE
feat: allow env var for pw in u2c.py

### DIFF
--- a/bin/u2c.py
+++ b/bin/u2c.py
@@ -1576,7 +1576,7 @@ NOTE: if server has --usernames enabled, then password is "username:password"
     ap.add_argument("url", type=unicode, help="server url, including destination folder")
     ap.add_argument("files", type=files_decoder, nargs="+", help="files and/or folders to process")
     ap.add_argument("-v", action="store_true", help="verbose")
-    ap.add_argument("-a", metavar="PASSWD", default="", help="password (or $filepath) for copyparty (is sent in header 'PW')")
+    ap.add_argument("-a", metavar="PASSWD", default="", help="password (or $filepath) for copyparty, if omitted uses env var PASSWD (is sent in header 'PW')")
     ap.add_argument("--ba", metavar="PASSWD", default="", help="password (or $filepath) for basic-auth (usually not necessary)")
     ap.add_argument("-s", action="store_true", help="file-search (disables upload)")
     ap.add_argument("-x", type=unicode, metavar="REGEX", action="append", help="skip file if filesystem-abspath matches REGEX (option can be repeated), example: '.*/\\.hist/.*'")
@@ -1728,6 +1728,9 @@ NOTE: if server has --usernames enabled, then password is "username:password"
             print("reading password from file [%s]" % (zs[1:],))
             with open(zs[1:], "rb") as f:
                 setattr(ar, k, f.read().decode("utf-8").strip())
+    
+    if not ar.a and os.getenv('PASSWD'):
+            ar.a = os.getenv('PASSWD')
 
     if ar.ba:
         ar.ba = "Basic " + base64.b64encode(ar.ba.encode("utf-8")).decode("utf-8")

--- a/bin/u2c.py
+++ b/bin/u2c.py
@@ -1576,7 +1576,7 @@ NOTE: if server has --usernames enabled, then password is "username:password"
     ap.add_argument("url", type=unicode, help="server url, including destination folder")
     ap.add_argument("files", type=files_decoder, nargs="+", help="files and/or folders to process")
     ap.add_argument("-v", action="store_true", help="verbose")
-    ap.add_argument("-a", metavar="PASSWD", default="", help="password (or $filepath) for copyparty, if omitted uses env var PASSWD (is sent in header 'PW')")
+    ap.add_argument("-a", metavar="PASSWD", default="", help="password (or $filepath) for copyparty, if omitted uses env var U2C_PW (is sent in header 'PW')")
     ap.add_argument("--ba", metavar="PASSWD", default="", help="password (or $filepath) for basic-auth (usually not necessary)")
     ap.add_argument("-s", action="store_true", help="file-search (disables upload)")
     ap.add_argument("-x", type=unicode, metavar="REGEX", action="append", help="skip file if filesystem-abspath matches REGEX (option can be repeated), example: '.*/\\.hist/.*'")
@@ -1729,8 +1729,8 @@ NOTE: if server has --usernames enabled, then password is "username:password"
             with open(zs[1:], "rb") as f:
                 setattr(ar, k, f.read().decode("utf-8").strip())
     
-    if not ar.a and os.getenv('PASSWD'):
-            ar.a = os.getenv('PASSWD')
+    if not ar.a and os.getenv('U2C_PWD'):
+            ar.a = os.getenv('U2C_PW')
 
     if ar.ba:
         ar.ba = "Basic " + base64.b64encode(ar.ba.encode("utf-8")).decode("utf-8")

--- a/bin/u2c.py
+++ b/bin/u2c.py
@@ -1729,7 +1729,7 @@ NOTE: if server has --usernames enabled, then password is "username:password"
             with open(zs[1:], "rb") as f:
                 setattr(ar, k, f.read().decode("utf-8").strip())
     
-    if not ar.a and os.getenv('U2C_PWD'):
+    if not ar.a and os.getenv('U2C_PW'):
             ar.a = os.getenv('U2C_PW')
 
     if ar.ba:

--- a/bin/u2c.py
+++ b/bin/u2c.py
@@ -1576,7 +1576,7 @@ NOTE: if server has --usernames enabled, then password is "username:password"
     ap.add_argument("url", type=unicode, help="server url, including destination folder")
     ap.add_argument("files", type=files_decoder, nargs="+", help="files and/or folders to process")
     ap.add_argument("-v", action="store_true", help="verbose")
-    ap.add_argument("-a", metavar="PASSWD", default="", help="password (or $filepath) for copyparty, if omitted uses env var U2C_PW (is sent in header 'PW')")
+    ap.add_argument("-a", metavar="PASSWD", default="", help="password (or $filepath) for copyparty (is sent in header 'PW'), default is env.var U2C_PW")
     ap.add_argument("--ba", metavar="PASSWD", default="", help="password (or $filepath) for basic-auth (usually not necessary)")
     ap.add_argument("-s", action="store_true", help="file-search (disables upload)")
     ap.add_argument("-x", type=unicode, metavar="REGEX", action="append", help="skip file if filesystem-abspath matches REGEX (option can be repeated), example: '.*/\\.hist/.*'")
@@ -1728,9 +1728,9 @@ NOTE: if server has --usernames enabled, then password is "username:password"
             print("reading password from file [%s]" % (zs[1:],))
             with open(zs[1:], "rb") as f:
                 setattr(ar, k, f.read().decode("utf-8").strip())
-    
-    if not ar.a and os.getenv('U2C_PW'):
-            ar.a = os.getenv('U2C_PW')
+
+    if not ar.a:
+        ar.a = os.environ.get("U2C_PW", "")
 
     if ar.ba:
         ar.ba = "Basic " + base64.b64encode(ar.ba.encode("utf-8")).decode("utf-8")


### PR DESCRIPTION
for the `u2c.py` script, allows grabbing password from an env var instead of direct from command line or a file. this is helpful for use with systemd and `EnviornmentFile`. not really the _most_ useful, but i wanted it so...

just a simple demo, for sanity's sake
<img width="516" height="400" alt="image" src="https://github.com/user-attachments/assets/08d7f952-991e-4e78-b5e5-68c21274185e" />

To show that your contribution is compatible with the MIT License, please include the following text somewhere in this PR description:  
This PR complies with the DCO; https://developercertificate.org/  
